### PR TITLE
feat: add calm, restrained marketing2 site in all 6 languages

### DIFF
--- a/frontend/src/lib/stores/marketing2.ts
+++ b/frontend/src/lib/stores/marketing2.ts
@@ -1,0 +1,61 @@
+/**
+ * Marketing2 Store
+ *
+ * Handles language selection and provides translations for the
+ * calm, restrained marketing site.
+ */
+
+import { writable, derived } from "svelte/store";
+import { marketing2Dictionary, type Marketing2Language } from "./marketing2Dictionary";
+
+// Language state - defaults to English, persists choice
+function createLanguageStore() {
+    // Try to get saved language from localStorage (browser only)
+    const getInitialLanguage = (): Marketing2Language => {
+        if (typeof window !== "undefined") {
+            const saved = localStorage.getItem("continuum_marketing_lang");
+            if (saved && saved in marketing2Dictionary) {
+                return saved as Marketing2Language;
+            }
+            // Try to detect from browser
+            const browserLang = navigator.language?.split("-")[0];
+            if (browserLang && browserLang in marketing2Dictionary) {
+                return browserLang as Marketing2Language;
+            }
+        }
+        return "en";
+    };
+
+    const { subscribe, set, update } = writable<Marketing2Language>(getInitialLanguage());
+
+    return {
+        subscribe,
+        set: (lang: Marketing2Language) => {
+            if (typeof window !== "undefined") {
+                localStorage.setItem("continuum_marketing_lang", lang);
+            }
+            set(lang);
+        },
+        update
+    };
+}
+
+export const m2Language = createLanguageStore();
+
+// Derived store that returns the translations for the current language
+export const m2t = derived(m2Language, ($lang) => {
+    return marketing2Dictionary[$lang] || marketing2Dictionary.en;
+});
+
+// Available languages for the language selector
+export const availableLanguages = [
+    { code: "en", name: "English", native: "English" },
+    { code: "es", name: "Spanish", native: "Español" },
+    { code: "fr", name: "French", native: "Français" },
+    { code: "de", name: "German", native: "Deutsch" },
+    { code: "ru", name: "Russian", native: "Русский" },
+    { code: "he", name: "Hebrew", native: "עברית", rtl: true }
+] as const;
+
+// Helper to check if current language is RTL
+export const isRTL = derived(m2Language, ($lang) => $lang === "he");

--- a/frontend/src/lib/stores/marketing2Dictionary.ts
+++ b/frontend/src/lib/stores/marketing2Dictionary.ts
@@ -33,7 +33,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "You don't have to know where to start.",
         guideDesc: "Continuum's guide walks beside you—suggesting what might matter, translating the confusing parts, helping you find words for things you've never had to say.",
-        guideReassurance: "There's no right order. No required fields. Just gentle guidance, at your pace.",
+        guideReassurance: "There's no right order. No required fields. Gentle guidance, at your pace.",
 
         // Section 4: The Pulse
         pulseTitle: "You don't have to have the difficult conversation.",
@@ -75,7 +75,7 @@ export const marketing2Dictionary = {
         signupWelcome: "Welcome,",
         signupNext: "Your space is ready. Take all the time you need.",
         signupEnter: "Enter Continuum",
-        signupBack: "Go back",
+        signupBack: "Return",
 
         // Features page (minimal)
         featuresTitle: "What's inside",
@@ -92,11 +92,32 @@ export const marketing2Dictionary = {
         // How it works (3 beats)
         howTitle: "How it works",
         howBeat1Title: "You start, wherever feels right.",
-        howBeat1Desc: "The guide asks simple questions. Suggests what might matter. You go at your own pace.",
+        howBeat1Desc: "The guide asks gentle questions. Suggests what might matter. You go at your own pace.",
         howBeat2Title: "You build, over time.",
         howBeat2Desc: "Documents. Wishes. Letters. Whatever you're ready for. Skip anything that doesn't feel right today.",
         howBeat3Title: "It opens, when needed.",
         howBeat3Desc: "Set up your Pulse. Check in now and then. If you stop, it reaches out to the people you trust—and gives them exactly what they need.",
+        howIntro: "Three gentle steps. No complexity. No overwhelm.",
+
+        // Feature list items
+        practicalItem1: "Financial accounts & policies",
+        practicalItem2: "Legal documents & wills",
+        practicalItem3: "Key contacts & advisors",
+        practicalItem4: "Home access & passwords",
+        personalItem1: "Letters for the future",
+        personalItem2: "Heirlooms with stories",
+        personalItem3: "Photos & memories",
+        personalItem4: "Life timeline & legacy journal",
+        protectiveItem1: "Medical wishes & directives",
+        protectiveItem2: "Pet care instructions",
+        protectiveItem3: "The Pulse check-in system",
+        protectiveItem4: "Safety timer for peace of mind",
+        preparedItem1: "Executor toolkit & checklists",
+        preparedItem2: "The Red Binder (printable backup)",
+        preparedItem3: "QR code access for guardians",
+        preparedItem4: "Practice run simulator",
+        featuresMore: "There's more here than you'll ever need. That's the point. Whatever your situation—complicated family, multiple properties, beloved pets, specific wishes—Continuum has a place for it.",
+        featuresMoreSub: "You'll find it when you need it. The guide will take you there.",
 
         // Footer
         footerDisclaimer: "Continuum is a documentation and organization tool. We do not provide legal, financial, tax, or medical advice.",
@@ -124,7 +145,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "No tienes que saber por dónde empezar.",
         guideDesc: "La guía de Continuum camina a tu lado—sugiriendo lo que podría importar, traduciendo las partes confusas, ayudándote a encontrar palabras para cosas que nunca has tenido que decir.",
-        guideReassurance: "No hay un orden correcto. No hay campos obligatorios. Solo orientación gentil, a tu ritmo.",
+        guideReassurance: "No hay un orden correcto. No hay campos obligatorios. Orientación gentil, a tu ritmo.",
 
         // Section 4: The Pulse
         pulseTitle: "No tienes que tener la conversación difícil.",
@@ -182,12 +203,33 @@ export const marketing2Dictionary = {
 
         // How it works
         howTitle: "Cómo funciona",
+        howIntro: "Tres pasos amables. Sin complejidad. Sin agobio.",
         howBeat1Title: "Empiezas donde te sientas cómodo.",
-        howBeat1Desc: "La guía hace preguntas simples. Sugiere lo que podría importar. Vas a tu propio ritmo.",
+        howBeat1Desc: "La guía hace preguntas amables. Sugiere lo que podría importar. Vas a tu propio ritmo.",
         howBeat2Title: "Construyes, con el tiempo.",
         howBeat2Desc: "Documentos. Deseos. Cartas. Lo que estés listo para hacer. Salta cualquier cosa que no se sienta bien hoy.",
         howBeat3Title: "Se abre, cuando es necesario.",
         howBeat3Desc: "Configura tu Pulso. Confirma de vez en cuando. Si dejas de hacerlo, contacta a las personas en las que confías—y les da exactamente lo que necesitan.",
+
+        // Feature list items
+        practicalItem1: "Cuentas financieras y pólizas",
+        practicalItem2: "Documentos legales y testamentos",
+        practicalItem3: "Contactos clave y asesores",
+        practicalItem4: "Acceso al hogar y contraseñas",
+        personalItem1: "Cartas para el futuro",
+        personalItem2: "Reliquias con historias",
+        personalItem3: "Fotos y recuerdos",
+        personalItem4: "Línea de vida y diario de legado",
+        protectiveItem1: "Deseos y directivas médicas",
+        protectiveItem2: "Instrucciones de cuidado de mascotas",
+        protectiveItem3: "El sistema de check-in Pulso",
+        protectiveItem4: "Temporizador de seguridad para tranquilidad",
+        preparedItem1: "Kit de herramientas y listas para el albacea",
+        preparedItem2: "La Carpeta Roja (respaldo imprimible)",
+        preparedItem3: "Acceso por código QR para guardianes",
+        preparedItem4: "Simulador de prueba",
+        featuresMore: "Hay más aquí de lo que jamás necesitarás. Ese es el punto. Sea cual sea tu situación—familia complicada, múltiples propiedades, mascotas queridas, deseos específicos—Continuum tiene un lugar para ello.",
+        featuresMoreSub: "Lo encontrarás cuando lo necesites. La guía te llevará allí.",
 
         // Footer
         footerDisclaimer: "Continuum es una herramienta de documentación y organización. No proporcionamos asesoramiento legal, financiero, fiscal o médico.",
@@ -215,7 +257,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "Vous n'avez pas besoin de savoir par où commencer.",
         guideDesc: "Le guide de Continuum marche à vos côtés—suggérant ce qui pourrait compter, traduisant les parties confuses, vous aidant à trouver les mots pour des choses que vous n'avez jamais eu à dire.",
-        guideReassurance: "Il n'y a pas d'ordre correct. Pas de champs obligatoires. Juste des conseils bienveillants, à votre rythme.",
+        guideReassurance: "Il n'y a pas d'ordre correct. Pas de champs obligatoires. Des conseils bienveillants, à votre rythme.",
 
         // Section 4: The Pulse
         pulseTitle: "Vous n'avez pas besoin d'avoir la conversation difficile.",
@@ -273,12 +315,33 @@ export const marketing2Dictionary = {
 
         // How it works
         howTitle: "Comment ça marche",
+        howIntro: "Trois étapes douces. Pas de complexité. Pas de surcharge.",
         howBeat1Title: "Vous commencez où vous vous sentez à l'aise.",
-        howBeat1Desc: "Le guide pose des questions simples. Suggère ce qui pourrait compter. Vous allez à votre propre rythme.",
+        howBeat1Desc: "Le guide pose des questions douces. Suggère ce qui pourrait compter. Vous allez à votre propre rythme.",
         howBeat2Title: "Vous construisez, au fil du temps.",
         howBeat2Desc: "Documents. Souhaits. Lettres. Ce pour quoi vous êtes prêt. Sautez tout ce qui ne vous semble pas juste aujourd'hui.",
         howBeat3Title: "Il s'ouvre, quand c'est nécessaire.",
         howBeat3Desc: "Configurez votre Pulse. Confirmez de temps en temps. Si vous arrêtez, il contacte les personnes de confiance—et leur donne exactement ce dont ils ont besoin.",
+
+        // Feature list items
+        practicalItem1: "Comptes financiers et polices",
+        practicalItem2: "Documents juridiques et testaments",
+        practicalItem3: "Contacts clés et conseillers",
+        practicalItem4: "Accès à la maison et mots de passe",
+        personalItem1: "Lettres pour l'avenir",
+        personalItem2: "Héritages avec leurs histoires",
+        personalItem3: "Photos et souvenirs",
+        personalItem4: "Chronologie de vie et journal de transmission",
+        protectiveItem1: "Souhaits et directives médicales",
+        protectiveItem2: "Instructions pour le soin des animaux",
+        protectiveItem3: "Le système de confirmation Pulse",
+        protectiveItem4: "Minuterie de sécurité pour la tranquillité d'esprit",
+        preparedItem1: "Boîte à outils et listes pour l'exécuteur",
+        preparedItem2: "Le Classeur Rouge (sauvegarde imprimable)",
+        preparedItem3: "Accès par code QR pour les tuteurs",
+        preparedItem4: "Simulateur de test",
+        featuresMore: "Il y a plus ici que vous n'en aurez jamais besoin. C'est le but. Quelle que soit votre situation—famille compliquée, propriétés multiples, animaux de compagnie adorés, souhaits spécifiques—Continuum a une place pour cela.",
+        featuresMoreSub: "Vous le trouverez quand vous en aurez besoin. Le guide vous y mènera.",
 
         // Footer
         footerDisclaimer: "Continuum est un outil de documentation et d'organisation. Nous ne fournissons pas de conseils juridiques, financiers, fiscaux ou médicaux.",
@@ -306,7 +369,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "Sie müssen nicht wissen, wo Sie anfangen sollen.",
         guideDesc: "Der Continuum-Leitfaden begleitet Sie—schlägt vor, was wichtig sein könnte, übersetzt verwirrende Teile, hilft Ihnen, Worte für Dinge zu finden, die Sie nie sagen mussten.",
-        guideReassurance: "Es gibt keine richtige Reihenfolge. Keine Pflichtfelder. Nur sanfte Anleitung, in Ihrem Tempo.",
+        guideReassurance: "Es gibt keine richtige Reihenfolge. Keine Pflichtfelder. Sanfte Anleitung, in Ihrem Tempo.",
 
         // Section 4: The Pulse
         pulseTitle: "Sie müssen das schwierige Gespräch nicht führen.",
@@ -364,12 +427,33 @@ export const marketing2Dictionary = {
 
         // How it works
         howTitle: "So funktioniert es",
+        howIntro: "Drei sanfte Schritte. Keine Komplexität. Keine Überforderung.",
         howBeat1Title: "Sie beginnen, wo es sich richtig anfühlt.",
-        howBeat1Desc: "Der Leitfaden stellt einfache Fragen. Schlägt vor, was wichtig sein könnte. Sie gehen in Ihrem eigenen Tempo.",
+        howBeat1Desc: "Der Leitfaden stellt sanfte Fragen. Schlägt vor, was wichtig sein könnte. Sie gehen in Ihrem eigenen Tempo.",
         howBeat2Title: "Sie bauen auf, mit der Zeit.",
         howBeat2Desc: "Dokumente. Wünsche. Briefe. Wofür Sie bereit sind. Überspringen Sie alles, was sich heute nicht richtig anfühlt.",
         howBeat3Title: "Es öffnet sich, wenn nötig.",
         howBeat3Desc: "Richten Sie Ihren Puls ein. Bestätigen Sie ab und zu. Wenn Sie aufhören, kontaktiert es die Menschen, denen Sie vertrauen—und gibt ihnen genau das, was sie brauchen.",
+
+        // Feature list items
+        practicalItem1: "Finanzkonten und Policen",
+        practicalItem2: "Rechtliche Dokumente und Testamente",
+        practicalItem3: "Wichtige Kontakte und Berater",
+        practicalItem4: "Hauszugang und Passwörter",
+        personalItem1: "Briefe für die Zukunft",
+        personalItem2: "Erbstücke mit Geschichten",
+        personalItem3: "Fotos und Erinnerungen",
+        personalItem4: "Lebenszeitlinie und Vermächtnistagebuch",
+        protectiveItem1: "Medizinische Wünsche und Verfügungen",
+        protectiveItem2: "Anweisungen zur Tierpflege",
+        protectiveItem3: "Das Puls-Check-in-System",
+        protectiveItem4: "Sicherheitstimer für Seelenruhe",
+        preparedItem1: "Werkzeugkasten und Checklisten für den Testamentsvollstrecker",
+        preparedItem2: "Der Rote Ordner (druckbare Sicherung)",
+        preparedItem3: "QR-Code-Zugang für Vertrauenspersonen",
+        preparedItem4: "Probelauf-Simulator",
+        featuresMore: "Es gibt hier mehr, als Sie jemals brauchen werden. Das ist der Punkt. Was auch immer Ihre Situation ist—komplizierte Familie, mehrere Immobilien, geliebte Haustiere, spezielle Wünsche—Continuum hat einen Platz dafür.",
+        featuresMoreSub: "Sie werden es finden, wenn Sie es brauchen. Der Leitfaden bringt Sie dorthin.",
 
         // Footer
         footerDisclaimer: "Continuum ist ein Dokumentations- und Organisationswerkzeug. Wir bieten keine rechtliche, finanzielle, steuerliche oder medizinische Beratung.",
@@ -397,7 +481,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "Вам не нужно знать, с чего начать.",
         guideDesc: "Гид Continuum идёт рядом с вами—подсказывает, что может быть важным, переводит запутанные части, помогает найти слова для того, что вам никогда не приходилось говорить.",
-        guideReassurance: "Нет правильного порядка. Нет обязательных полей. Только мягкое руководство в вашем темпе.",
+        guideReassurance: "Нет правильного порядка. Нет обязательных полей. Мягкое руководство в вашем темпе.",
 
         // Section 4: The Pulse
         pulseTitle: "Вам не нужно вести трудный разговор.",
@@ -455,12 +539,33 @@ export const marketing2Dictionary = {
 
         // How it works
         howTitle: "Как это работает",
+        howIntro: "Три мягких шага. Без сложностей. Без перегрузки.",
         howBeat1Title: "Вы начинаете там, где чувствуете себя комфортно.",
-        howBeat1Desc: "Гид задаёт простые вопросы. Подсказывает, что может быть важным. Вы идёте в своём темпе.",
+        howBeat1Desc: "Гид задаёт мягкие вопросы. Подсказывает, что может быть важным. Вы идёте в своём темпе.",
         howBeat2Title: "Вы строите со временем.",
         howBeat2Desc: "Документы. Пожелания. Письма. То, к чему вы готовы. Пропускайте всё, что сегодня не кажется правильным.",
         howBeat3Title: "Оно открывается, когда нужно.",
         howBeat3Desc: "Настройте свой Пульс. Подтверждайте время от времени. Если вы перестанете, оно свяжется с людьми, которым вы доверяете—и даст им именно то, что нужно.",
+
+        // Feature list items
+        practicalItem1: "Финансовые счета и полисы",
+        practicalItem2: "Юридические документы и завещания",
+        practicalItem3: "Ключевые контакты и консультанты",
+        practicalItem4: "Доступ к дому и пароли",
+        personalItem1: "Письма в будущее",
+        personalItem2: "Реликвии с историями",
+        personalItem3: "Фотографии и воспоминания",
+        personalItem4: "Хроника жизни и дневник наследия",
+        protectiveItem1: "Медицинские пожелания и распоряжения",
+        protectiveItem2: "Инструкции по уходу за питомцами",
+        protectiveItem3: "Система подтверждения Пульс",
+        protectiveItem4: "Таймер безопасности для спокойствия",
+        preparedItem1: "Набор инструментов и чек-листы для душеприказчика",
+        preparedItem2: "Красная Папка (печатная резервная копия)",
+        preparedItem3: "QR-код доступа для опекунов",
+        preparedItem4: "Симулятор пробного запуска",
+        featuresMore: "Здесь больше, чем вам когда-либо понадобится. В этом и смысл. Какова бы ни была ваша ситуация—сложная семья, несколько объектов недвижимости, любимые питомцы, особые пожелания—в Continuum есть место для всего.",
+        featuresMoreSub: "Вы найдёте это, когда понадобится. Гид приведёт вас туда.",
 
         // Footer
         footerDisclaimer: "Continuum — это инструмент документирования и организации. Мы не предоставляем юридических, финансовых, налоговых или медицинских консультаций.",
@@ -488,7 +593,7 @@ export const marketing2Dictionary = {
         // Section 3: The Guide
         guideTitle: "אתם לא צריכים לדעת מאיפה להתחיל.",
         guideDesc: "המדריך של Continuum הולך לצידכם—מציע מה עשוי להיות חשוב, מתרגם את החלקים המבלבלים, עוזר לכם למצוא מילים לדברים שמעולם לא הייתם צריכים לומר.",
-        guideReassurance: "אין סדר נכון. אין שדות חובה. רק הדרכה עדינה, בקצב שלכם.",
+        guideReassurance: "אין סדר נכון. אין שדות חובה. הדרכה עדינה, בקצב שלכם.",
 
         // Section 4: The Pulse
         pulseTitle: "אתם לא צריכים לנהל את השיחה הקשה.",
@@ -546,12 +651,33 @@ export const marketing2Dictionary = {
 
         // How it works
         howTitle: "איך זה עובד",
+        howIntro: "שלושה צעדים עדינים. בלי מורכבות. בלי עומס.",
         howBeat1Title: "אתם מתחילים איפה שמרגיש נכון.",
-        howBeat1Desc: "המדריך שואל שאלות פשוטות. מציע מה עשוי להיות חשוב. אתם הולכים בקצב שלכם.",
+        howBeat1Desc: "המדריך שואל שאלות עדינות. מציע מה עשוי להיות חשוב. אתם הולכים בקצב שלכם.",
         howBeat2Title: "אתם בונים, עם הזמן.",
         howBeat2Desc: "מסמכים. משאלות. מכתבים. מה שאתם מוכנים אליו. דלגו על כל מה שלא מרגיש נכון היום.",
         howBeat3Title: "זה נפתח, כשצריך.",
         howBeat3Desc: "הגדירו את הפולס שלכם. אשרו מדי פעם. אם תפסיקו, זה פונה לאנשים שאתם סומכים עליהם—ונותן להם בדיוק מה שהם צריכים.",
+
+        // Feature list items
+        practicalItem1: "חשבונות פיננסיים ופוליסות",
+        practicalItem2: "מסמכים משפטיים וצוואות",
+        practicalItem3: "אנשי קשר מרכזיים ויועצים",
+        practicalItem4: "גישה לבית וסיסמאות",
+        personalItem1: "מכתבים לעתיד",
+        personalItem2: "חפצי ערך עם סיפורים",
+        personalItem3: "תמונות וזיכרונות",
+        personalItem4: "ציר זמן החיים ויומן מורשת",
+        protectiveItem1: "משאלות והנחיות רפואיות",
+        protectiveItem2: "הוראות לטיפול בחיות מחמד",
+        protectiveItem3: "מערכת האישור פולס",
+        protectiveItem4: "טיימר בטיחות לשקט נפשי",
+        preparedItem1: "ערכת כלים ורשימות למנהל העיזבון",
+        preparedItem2: "הקלסר האדום (גיבוי להדפסה)",
+        preparedItem3: "גישה בקוד QR לאפוטרופוסים",
+        preparedItem4: "סימולטור ניסיון",
+        featuresMore: "יש כאן יותר ממה שתצטרכו אי פעם. זו הנקודה. לא משנה מה המצב שלכם—משפחה מסובכת, נכסים מרובים, חיות מחמד אהובות, משאלות ספציפיות—ל-Continuum יש מקום לזה.",
+        featuresMoreSub: "תמצאו את זה כשתצטרכו. המדריך ייקח אתכם לשם.",
 
         // Footer
         footerDisclaimer: "Continuum הוא כלי תיעוד וארגון. איננו מספקים ייעוץ משפטי, פיננסי, מס או רפואי.",

--- a/frontend/src/lib/stores/marketing2Dictionary.ts
+++ b/frontend/src/lib/stores/marketing2Dictionary.ts
@@ -1,0 +1,569 @@
+/**
+ * Marketing2 Dictionary
+ *
+ * Calm, restrained marketing content following the revised plan:
+ * - Emotion first, features later
+ * - Progressive disclosure (hint at depth, never overwhelm)
+ * - Tone compliant (invitation over instruction, acknowledgment over efficiency)
+ * - Owner-focused (executors/recipients come via product, not marketing)
+ *
+ * 7 Sections:
+ * 1. The Shoebox - Recognition
+ * 2. The Weight - The problem
+ * 3. The Guide - AI assistance (permission to not know)
+ * 4. The Pulse - Automated handover
+ * 5. The Distinction - Not lawyers/financial advisors
+ * 6. The Gift - What they receive
+ * 7. The Invitation - Begin when ready
+ */
+
+export const marketing2Dictionary = {
+    en: {
+        // Section 1: The Shoebox
+        heroLine1: "Your parents had a shoebox",
+        heroLine2: "under the bed.",
+        heroLine3: "You have Continuum.",
+        heroDesc: "A calm place to organize your life for the people you love.",
+
+        // Section 2: The Weight
+        weightTitle: "Someday, someone will need to figure out your life.",
+        weightDesc: "Where's the will? What accounts exist? What did you want? They'll be grieving. And searching. Unless you leave them something better than a drawer full of questions.",
+        weightBridge: "Continuum makes sure they're not alone when that day comes.",
+
+        // Section 3: The Guide
+        guideTitle: "You don't have to know where to start.",
+        guideDesc: "Continuum's guide walks beside you—suggesting what might matter, translating the confusing parts, helping you find words for things you've never had to say.",
+        guideReassurance: "There's no right order. No required fields. Just gentle guidance, at your pace.",
+
+        // Section 4: The Pulse
+        pulseTitle: "You don't have to have the difficult conversation.",
+        pulseDesc: "Set up your Pulse. Check in every few days—a simple \"I'm here.\" And if one day you're not there to check in, Continuum notices.",
+        pulseHow: "It reaches out to the people you chose. Opens the right doors, at the right time. Your executor won't face a mystery. They'll receive clarity.",
+        pulseGift: "You already took care of them. This was your final gift.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "We're not lawyers or financial advisors.",
+        distinctionDesc: "Continuum doesn't write wills or give financial advice. Your professionals do that.",
+        distinctionRole: "We're the organization layer. We help you gather what they create—and what you want to say—so it's found, understood, and used.",
+        distinctionTagline: "They create the plan. We make sure it works.",
+
+        // Section 6: The Gift
+        giftTitle: "What they'll receive",
+        giftClarity: "Clarity",
+        giftClarityDesc: "Everything organized. Nothing to hunt for.",
+        giftGuidance: "Guidance",
+        giftGuidanceDesc: "Step-by-step help when they need it most.",
+        giftVoice: "Your voice",
+        giftVoiceDesc: "Letters, wishes, context—in your words.",
+
+        // Section 7: The Invitation
+        invitationTitle: "Begin when you're ready.",
+        invitationDesc: "There's no deadline here. No pressure. Come back whenever you want.",
+        invitationTagline: "Continuum will be waiting.",
+
+        // CTA
+        ctaPrimary: "Begin when you're ready",
+        ctaExplore: "Explore what's inside",
+
+        // Signup flow
+        signupTitle: "Let's start simply.",
+        signupNamePrompt: "What should we call you?",
+        signupNamePlaceholder: "Your first name",
+        signupEmailPrompt: "Where can we reach you?",
+        signupEmailPlaceholder: "Your email",
+        signupButton: "Continue",
+        signupWelcome: "Welcome,",
+        signupNext: "Your space is ready. Take all the time you need.",
+        signupEnter: "Enter Continuum",
+        signupBack: "Go back",
+
+        // Features page (minimal)
+        featuresTitle: "What's inside",
+        featuresIntro: "Continuum has dozens of tools. You don't need to learn them all. Start anywhere. The guide takes you where you need to go.",
+        featurePracticalTitle: "The Practical",
+        featurePracticalDesc: "Accounts. Documents. Contacts. The things they'll need to find.",
+        featurePersonalTitle: "The Personal",
+        featurePersonalDesc: "Letters. Heirlooms. Memories. The things that carry meaning.",
+        featureProtectiveTitle: "The Protective",
+        featureProtectiveDesc: "Medical wishes. Pet care. The Pulse. Making sure the living are cared for.",
+        featurePreparedTitle: "The Prepared",
+        featurePreparedDesc: "Tools for your executor. A binder they can hold. A system they can trust.",
+
+        // How it works (3 beats)
+        howTitle: "How it works",
+        howBeat1Title: "You start, wherever feels right.",
+        howBeat1Desc: "The guide asks simple questions. Suggests what might matter. You go at your own pace.",
+        howBeat2Title: "You build, over time.",
+        howBeat2Desc: "Documents. Wishes. Letters. Whatever you're ready for. Skip anything that doesn't feel right today.",
+        howBeat3Title: "It opens, when needed.",
+        howBeat3Desc: "Set up your Pulse. Check in now and then. If you stop, it reaches out to the people you trust—and gives them exactly what they need.",
+
+        // Footer
+        footerDisclaimer: "Continuum is a documentation and organization tool. We do not provide legal, financial, tax, or medical advice.",
+        footerTagline: "The organized life. The gentle handover.",
+
+        // Navigation
+        navHow: "How it works",
+        navFeatures: "Features",
+        navSecurity: "Security",
+        navLogin: "Enter"
+    },
+
+    es: {
+        // Section 1: The Shoebox
+        heroLine1: "Tus padres tenían una caja de zapatos",
+        heroLine2: "bajo la cama.",
+        heroLine3: "Tú tienes Continuum.",
+        heroDesc: "Un lugar tranquilo para organizar tu vida para las personas que amas.",
+
+        // Section 2: The Weight
+        weightTitle: "Algún día, alguien tendrá que descifrar tu vida.",
+        weightDesc: "¿Dónde está el testamento? ¿Qué cuentas existen? ¿Qué querías? Estarán de duelo. Y buscando. A menos que les dejes algo mejor que un cajón lleno de preguntas.",
+        weightBridge: "Continuum se asegura de que no estén solos cuando llegue ese día.",
+
+        // Section 3: The Guide
+        guideTitle: "No tienes que saber por dónde empezar.",
+        guideDesc: "La guía de Continuum camina a tu lado—sugiriendo lo que podría importar, traduciendo las partes confusas, ayudándote a encontrar palabras para cosas que nunca has tenido que decir.",
+        guideReassurance: "No hay un orden correcto. No hay campos obligatorios. Solo orientación gentil, a tu ritmo.",
+
+        // Section 4: The Pulse
+        pulseTitle: "No tienes que tener la conversación difícil.",
+        pulseDesc: "Configura tu Pulso. Confirma cada pocos días—un simple \"Estoy aquí.\" Y si un día no estás para confirmar, Continuum lo nota.",
+        pulseHow: "Se comunica con las personas que elegiste. Abre las puertas correctas, en el momento correcto. Tu albacea no enfrentará un misterio. Recibirá claridad.",
+        pulseGift: "Ya cuidaste de ellos. Este fue tu último regalo.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "No somos abogados ni asesores financieros.",
+        distinctionDesc: "Continuum no redacta testamentos ni da asesoramiento financiero. Tus profesionales hacen eso.",
+        distinctionRole: "Somos la capa de organización. Te ayudamos a reunir lo que ellos crean—y lo que quieres decir—para que se encuentre, se entienda y se use.",
+        distinctionTagline: "Ellos crean el plan. Nosotros nos aseguramos de que funcione.",
+
+        // Section 6: The Gift
+        giftTitle: "Lo que recibirán",
+        giftClarity: "Claridad",
+        giftClarityDesc: "Todo organizado. Nada que buscar.",
+        giftGuidance: "Orientación",
+        giftGuidanceDesc: "Ayuda paso a paso cuando más la necesiten.",
+        giftVoice: "Tu voz",
+        giftVoiceDesc: "Cartas, deseos, contexto—en tus palabras.",
+
+        // Section 7: The Invitation
+        invitationTitle: "Comienza cuando estés listo.",
+        invitationDesc: "No hay fecha límite aquí. Sin presión. Vuelve cuando quieras.",
+        invitationTagline: "Continuum estará esperando.",
+
+        // CTA
+        ctaPrimary: "Comienza cuando estés listo",
+        ctaExplore: "Explora lo que hay dentro",
+
+        // Signup flow
+        signupTitle: "Empecemos de forma sencilla.",
+        signupNamePrompt: "¿Cómo deberíamos llamarte?",
+        signupNamePlaceholder: "Tu nombre",
+        signupEmailPrompt: "¿Dónde podemos contactarte?",
+        signupEmailPlaceholder: "Tu correo electrónico",
+        signupButton: "Continuar",
+        signupWelcome: "Bienvenido,",
+        signupNext: "Tu espacio está listo. Tómate todo el tiempo que necesites.",
+        signupEnter: "Entrar a Continuum",
+        signupBack: "Volver",
+
+        // Features page
+        featuresTitle: "Lo que hay dentro",
+        featuresIntro: "Continuum tiene docenas de herramientas. No necesitas aprenderlas todas. Empieza donde quieras. La guía te lleva donde necesitas ir.",
+        featurePracticalTitle: "Lo Práctico",
+        featurePracticalDesc: "Cuentas. Documentos. Contactos. Las cosas que necesitarán encontrar.",
+        featurePersonalTitle: "Lo Personal",
+        featurePersonalDesc: "Cartas. Reliquias. Recuerdos. Las cosas que llevan significado.",
+        featureProtectiveTitle: "Lo Protector",
+        featureProtectiveDesc: "Deseos médicos. Cuidado de mascotas. El Pulso. Asegurando que los vivos estén cuidados.",
+        featurePreparedTitle: "Lo Preparado",
+        featurePreparedDesc: "Herramientas para tu albacea. Una carpeta que puedan sostener. Un sistema en el que puedan confiar.",
+
+        // How it works
+        howTitle: "Cómo funciona",
+        howBeat1Title: "Empiezas donde te sientas cómodo.",
+        howBeat1Desc: "La guía hace preguntas simples. Sugiere lo que podría importar. Vas a tu propio ritmo.",
+        howBeat2Title: "Construyes, con el tiempo.",
+        howBeat2Desc: "Documentos. Deseos. Cartas. Lo que estés listo para hacer. Salta cualquier cosa que no se sienta bien hoy.",
+        howBeat3Title: "Se abre, cuando es necesario.",
+        howBeat3Desc: "Configura tu Pulso. Confirma de vez en cuando. Si dejas de hacerlo, contacta a las personas en las que confías—y les da exactamente lo que necesitan.",
+
+        // Footer
+        footerDisclaimer: "Continuum es una herramienta de documentación y organización. No proporcionamos asesoramiento legal, financiero, fiscal o médico.",
+        footerTagline: "La vida organizada. La entrega gentil.",
+
+        // Navigation
+        navHow: "Cómo funciona",
+        navFeatures: "Funciones",
+        navSecurity: "Seguridad",
+        navLogin: "Entrar"
+    },
+
+    fr: {
+        // Section 1: The Shoebox
+        heroLine1: "Vos parents avaient une boîte à chaussures",
+        heroLine2: "sous le lit.",
+        heroLine3: "Vous avez Continuum.",
+        heroDesc: "Un espace serein pour organiser votre vie pour ceux que vous aimez.",
+
+        // Section 2: The Weight
+        weightTitle: "Un jour, quelqu'un devra comprendre votre vie.",
+        weightDesc: "Où est le testament ? Quels comptes existent ? Que vouliez-vous ? Ils seront en deuil. Et à la recherche. À moins que vous ne leur laissiez quelque chose de mieux qu'un tiroir plein de questions.",
+        weightBridge: "Continuum s'assure qu'ils ne seront pas seuls quand ce jour viendra.",
+
+        // Section 3: The Guide
+        guideTitle: "Vous n'avez pas besoin de savoir par où commencer.",
+        guideDesc: "Le guide de Continuum marche à vos côtés—suggérant ce qui pourrait compter, traduisant les parties confuses, vous aidant à trouver les mots pour des choses que vous n'avez jamais eu à dire.",
+        guideReassurance: "Il n'y a pas d'ordre correct. Pas de champs obligatoires. Juste des conseils bienveillants, à votre rythme.",
+
+        // Section 4: The Pulse
+        pulseTitle: "Vous n'avez pas besoin d'avoir la conversation difficile.",
+        pulseDesc: "Configurez votre Pulse. Confirmez tous les quelques jours—un simple « Je suis là ». Et si un jour vous n'êtes pas là pour confirmer, Continuum le remarque.",
+        pulseHow: "Il contacte les personnes que vous avez choisies. Ouvre les bonnes portes, au bon moment. Votre exécuteur ne fera pas face à un mystère. Il recevra de la clarté.",
+        pulseGift: "Vous avez déjà pris soin d'eux. C'était votre dernier cadeau.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "Nous ne sommes ni avocats ni conseillers financiers.",
+        distinctionDesc: "Continuum ne rédige pas de testaments et ne donne pas de conseils financiers. Vos professionnels font cela.",
+        distinctionRole: "Nous sommes la couche d'organisation. Nous vous aidons à rassembler ce qu'ils créent—et ce que vous voulez dire—pour que cela soit trouvé, compris et utilisé.",
+        distinctionTagline: "Ils créent le plan. Nous nous assurons qu'il fonctionne.",
+
+        // Section 6: The Gift
+        giftTitle: "Ce qu'ils recevront",
+        giftClarity: "Clarté",
+        giftClarityDesc: "Tout organisé. Rien à chercher.",
+        giftGuidance: "Accompagnement",
+        giftGuidanceDesc: "Une aide étape par étape quand ils en auront le plus besoin.",
+        giftVoice: "Votre voix",
+        giftVoiceDesc: "Lettres, souhaits, contexte—avec vos mots.",
+
+        // Section 7: The Invitation
+        invitationTitle: "Commencez quand vous êtes prêt.",
+        invitationDesc: "Il n'y a pas de date limite ici. Pas de pression. Revenez quand vous voulez.",
+        invitationTagline: "Continuum vous attendra.",
+
+        // CTA
+        ctaPrimary: "Commencer quand vous êtes prêt",
+        ctaExplore: "Explorer ce qu'il y a à l'intérieur",
+
+        // Signup flow
+        signupTitle: "Commençons simplement.",
+        signupNamePrompt: "Comment devrions-nous vous appeler ?",
+        signupNamePlaceholder: "Votre prénom",
+        signupEmailPrompt: "Où pouvons-nous vous joindre ?",
+        signupEmailPlaceholder: "Votre email",
+        signupButton: "Continuer",
+        signupWelcome: "Bienvenue,",
+        signupNext: "Votre espace est prêt. Prenez tout le temps dont vous avez besoin.",
+        signupEnter: "Entrer dans Continuum",
+        signupBack: "Retour",
+
+        // Features page
+        featuresTitle: "Ce qu'il y a à l'intérieur",
+        featuresIntro: "Continuum dispose de dizaines d'outils. Vous n'avez pas besoin de tous les apprendre. Commencez n'importe où. Le guide vous emmène là où vous devez aller.",
+        featurePracticalTitle: "Le Pratique",
+        featurePracticalDesc: "Comptes. Documents. Contacts. Les choses qu'ils auront besoin de trouver.",
+        featurePersonalTitle: "Le Personnel",
+        featurePersonalDesc: "Lettres. Souvenirs de famille. Mémoires. Les choses qui portent du sens.",
+        featureProtectiveTitle: "Le Protecteur",
+        featureProtectiveDesc: "Souhaits médicaux. Soins des animaux. Le Pulse. S'assurer que les vivants sont pris en charge.",
+        featurePreparedTitle: "Le Préparé",
+        featurePreparedDesc: "Outils pour votre exécuteur. Un classeur qu'ils peuvent tenir. Un système auquel ils peuvent faire confiance.",
+
+        // How it works
+        howTitle: "Comment ça marche",
+        howBeat1Title: "Vous commencez où vous vous sentez à l'aise.",
+        howBeat1Desc: "Le guide pose des questions simples. Suggère ce qui pourrait compter. Vous allez à votre propre rythme.",
+        howBeat2Title: "Vous construisez, au fil du temps.",
+        howBeat2Desc: "Documents. Souhaits. Lettres. Ce pour quoi vous êtes prêt. Sautez tout ce qui ne vous semble pas juste aujourd'hui.",
+        howBeat3Title: "Il s'ouvre, quand c'est nécessaire.",
+        howBeat3Desc: "Configurez votre Pulse. Confirmez de temps en temps. Si vous arrêtez, il contacte les personnes de confiance—et leur donne exactement ce dont ils ont besoin.",
+
+        // Footer
+        footerDisclaimer: "Continuum est un outil de documentation et d'organisation. Nous ne fournissons pas de conseils juridiques, financiers, fiscaux ou médicaux.",
+        footerTagline: "La vie organisée. La transmission douce.",
+
+        // Navigation
+        navHow: "Comment ça marche",
+        navFeatures: "Fonctionnalités",
+        navSecurity: "Sécurité",
+        navLogin: "Entrer"
+    },
+
+    de: {
+        // Section 1: The Shoebox
+        heroLine1: "Ihre Eltern hatten einen Schuhkarton",
+        heroLine2: "unter dem Bett.",
+        heroLine3: "Sie haben Continuum.",
+        heroDesc: "Ein ruhiger Ort, um Ihr Leben für die Menschen zu organisieren, die Sie lieben.",
+
+        // Section 2: The Weight
+        weightTitle: "Eines Tages wird jemand Ihr Leben verstehen müssen.",
+        weightDesc: "Wo ist das Testament? Welche Konten gibt es? Was wollten Sie? Sie werden trauern. Und suchen. Es sei denn, Sie hinterlassen ihnen etwas Besseres als eine Schublade voller Fragen.",
+        weightBridge: "Continuum stellt sicher, dass sie an diesem Tag nicht allein sind.",
+
+        // Section 3: The Guide
+        guideTitle: "Sie müssen nicht wissen, wo Sie anfangen sollen.",
+        guideDesc: "Der Continuum-Leitfaden begleitet Sie—schlägt vor, was wichtig sein könnte, übersetzt verwirrende Teile, hilft Ihnen, Worte für Dinge zu finden, die Sie nie sagen mussten.",
+        guideReassurance: "Es gibt keine richtige Reihenfolge. Keine Pflichtfelder. Nur sanfte Anleitung, in Ihrem Tempo.",
+
+        // Section 4: The Pulse
+        pulseTitle: "Sie müssen das schwierige Gespräch nicht führen.",
+        pulseDesc: "Richten Sie Ihren Puls ein. Bestätigen Sie alle paar Tage—ein einfaches „Ich bin hier." Und wenn Sie eines Tages nicht da sind, um zu bestätigen, bemerkt es Continuum.",
+        pulseHow: "Es wendet sich an die Menschen, die Sie gewählt haben. Öffnet die richtigen Türen, zur richtigen Zeit. Ihr Testamentsvollstrecker steht nicht vor einem Rätsel. Er erhält Klarheit.",
+        pulseGift: "Sie haben bereits für sie gesorgt. Das war Ihr letztes Geschenk.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "Wir sind keine Anwälte oder Finanzberater.",
+        distinctionDesc: "Continuum verfasst keine Testamente und gibt keine Finanzberatung. Das machen Ihre Fachleute.",
+        distinctionRole: "Wir sind die Organisationsebene. Wir helfen Ihnen, das zu sammeln, was sie erstellen—und was Sie sagen möchten—damit es gefunden, verstanden und verwendet wird.",
+        distinctionTagline: "Sie erstellen den Plan. Wir sorgen dafür, dass er funktioniert.",
+
+        // Section 6: The Gift
+        giftTitle: "Was sie erhalten werden",
+        giftClarity: "Klarheit",
+        giftClarityDesc: "Alles organisiert. Nichts zu suchen.",
+        giftGuidance: "Anleitung",
+        giftGuidanceDesc: "Schritt-für-Schritt-Hilfe, wenn sie sie am meisten brauchen.",
+        giftVoice: "Ihre Stimme",
+        giftVoiceDesc: "Briefe, Wünsche, Kontext—in Ihren Worten.",
+
+        // Section 7: The Invitation
+        invitationTitle: "Beginnen Sie, wenn Sie bereit sind.",
+        invitationDesc: "Hier gibt es keine Frist. Keinen Druck. Kommen Sie zurück, wann immer Sie möchten.",
+        invitationTagline: "Continuum wird warten.",
+
+        // CTA
+        ctaPrimary: "Beginnen, wenn Sie bereit sind",
+        ctaExplore: "Entdecken, was drin ist",
+
+        // Signup flow
+        signupTitle: "Fangen wir einfach an.",
+        signupNamePrompt: "Wie sollen wir Sie nennen?",
+        signupNamePlaceholder: "Ihr Vorname",
+        signupEmailPrompt: "Wo können wir Sie erreichen?",
+        signupEmailPlaceholder: "Ihre E-Mail",
+        signupButton: "Weiter",
+        signupWelcome: "Willkommen,",
+        signupNext: "Ihr Bereich ist bereit. Nehmen Sie sich alle Zeit, die Sie brauchen.",
+        signupEnter: "Continuum betreten",
+        signupBack: "Zurück",
+
+        // Features page
+        featuresTitle: "Was drin ist",
+        featuresIntro: "Continuum hat Dutzende von Werkzeugen. Sie müssen nicht alle lernen. Fangen Sie irgendwo an. Der Leitfaden bringt Sie dorthin, wo Sie sein müssen.",
+        featurePracticalTitle: "Das Praktische",
+        featurePracticalDesc: "Konten. Dokumente. Kontakte. Die Dinge, die sie finden müssen.",
+        featurePersonalTitle: "Das Persönliche",
+        featurePersonalDesc: "Briefe. Erbstücke. Erinnerungen. Die Dinge, die Bedeutung tragen.",
+        featureProtectiveTitle: "Das Schützende",
+        featureProtectiveDesc: "Medizinische Wünsche. Haustierpflege. Der Puls. Sicherstellen, dass die Lebenden versorgt sind.",
+        featurePreparedTitle: "Das Vorbereitete",
+        featurePreparedDesc: "Werkzeuge für Ihren Testamentsvollstrecker. Ein Ordner, den sie halten können. Ein System, dem sie vertrauen können.",
+
+        // How it works
+        howTitle: "So funktioniert es",
+        howBeat1Title: "Sie beginnen, wo es sich richtig anfühlt.",
+        howBeat1Desc: "Der Leitfaden stellt einfache Fragen. Schlägt vor, was wichtig sein könnte. Sie gehen in Ihrem eigenen Tempo.",
+        howBeat2Title: "Sie bauen auf, mit der Zeit.",
+        howBeat2Desc: "Dokumente. Wünsche. Briefe. Wofür Sie bereit sind. Überspringen Sie alles, was sich heute nicht richtig anfühlt.",
+        howBeat3Title: "Es öffnet sich, wenn nötig.",
+        howBeat3Desc: "Richten Sie Ihren Puls ein. Bestätigen Sie ab und zu. Wenn Sie aufhören, kontaktiert es die Menschen, denen Sie vertrauen—und gibt ihnen genau das, was sie brauchen.",
+
+        // Footer
+        footerDisclaimer: "Continuum ist ein Dokumentations- und Organisationswerkzeug. Wir bieten keine rechtliche, finanzielle, steuerliche oder medizinische Beratung.",
+        footerTagline: "Das organisierte Leben. Die sanfte Übergabe.",
+
+        // Navigation
+        navHow: "So funktioniert es",
+        navFeatures: "Funktionen",
+        navSecurity: "Sicherheit",
+        navLogin: "Eintreten"
+    },
+
+    ru: {
+        // Section 1: The Shoebox
+        heroLine1: "У ваших родителей была коробка из-под обуви",
+        heroLine2: "под кроватью.",
+        heroLine3: "У вас есть Continuum.",
+        heroDesc: "Спокойное место для организации вашей жизни для тех, кого вы любите.",
+
+        // Section 2: The Weight
+        weightTitle: "Когда-нибудь кому-то придётся разобраться в вашей жизни.",
+        weightDesc: "Где завещание? Какие счета существуют? Чего вы хотели? Они будут горевать. И искать. Если только вы не оставите им что-то лучшее, чем ящик, полный вопросов.",
+        weightBridge: "Continuum гарантирует, что они не будут одиноки, когда наступит этот день.",
+
+        // Section 3: The Guide
+        guideTitle: "Вам не нужно знать, с чего начать.",
+        guideDesc: "Гид Continuum идёт рядом с вами—подсказывает, что может быть важным, переводит запутанные части, помогает найти слова для того, что вам никогда не приходилось говорить.",
+        guideReassurance: "Нет правильного порядка. Нет обязательных полей. Только мягкое руководство в вашем темпе.",
+
+        // Section 4: The Pulse
+        pulseTitle: "Вам не нужно вести трудный разговор.",
+        pulseDesc: "Настройте свой Пульс. Подтверждайте каждые несколько дней—простое «Я здесь». И если однажды вас не будет, чтобы подтвердить, Continuum это заметит.",
+        pulseHow: "Он связывается с людьми, которых вы выбрали. Открывает нужные двери в нужное время. Ваш душеприказчик не столкнётся с загадкой. Он получит ясность.",
+        pulseGift: "Вы уже позаботились о них. Это был ваш последний подарок.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "Мы не юристы и не финансовые консультанты.",
+        distinctionDesc: "Continuum не составляет завещания и не даёт финансовых советов. Этим занимаются ваши специалисты.",
+        distinctionRole: "Мы — уровень организации. Мы помогаем вам собрать то, что они создают—и то, что вы хотите сказать—чтобы это было найдено, понято и использовано.",
+        distinctionTagline: "Они создают план. Мы следим за тем, чтобы он работал.",
+
+        // Section 6: The Gift
+        giftTitle: "Что они получат",
+        giftClarity: "Ясность",
+        giftClarityDesc: "Всё организовано. Ничего не нужно искать.",
+        giftGuidance: "Руководство",
+        giftGuidanceDesc: "Пошаговая помощь, когда она больше всего нужна.",
+        giftVoice: "Ваш голос",
+        giftVoiceDesc: "Письма, пожелания, контекст—вашими словами.",
+
+        // Section 7: The Invitation
+        invitationTitle: "Начните, когда будете готовы.",
+        invitationDesc: "Здесь нет крайних сроков. Никакого давления. Возвращайтесь, когда захотите.",
+        invitationTagline: "Continuum будет ждать.",
+
+        // CTA
+        ctaPrimary: "Начать, когда будете готовы",
+        ctaExplore: "Узнать, что внутри",
+
+        // Signup flow
+        signupTitle: "Начнём просто.",
+        signupNamePrompt: "Как нам вас называть?",
+        signupNamePlaceholder: "Ваше имя",
+        signupEmailPrompt: "Как с вами связаться?",
+        signupEmailPlaceholder: "Ваш email",
+        signupButton: "Продолжить",
+        signupWelcome: "Добро пожаловать,",
+        signupNext: "Ваше пространство готово. Не торопитесь.",
+        signupEnter: "Войти в Continuum",
+        signupBack: "Назад",
+
+        // Features page
+        featuresTitle: "Что внутри",
+        featuresIntro: "В Continuum десятки инструментов. Вам не нужно изучать их все. Начните где угодно. Гид приведёт вас туда, куда нужно.",
+        featurePracticalTitle: "Практичное",
+        featurePracticalDesc: "Счета. Документы. Контакты. То, что им нужно будет найти.",
+        featurePersonalTitle: "Личное",
+        featurePersonalDesc: "Письма. Семейные реликвии. Воспоминания. То, что несёт смысл.",
+        featureProtectiveTitle: "Защитное",
+        featureProtectiveDesc: "Медицинские пожелания. Уход за питомцами. Пульс. Забота о живых.",
+        featurePreparedTitle: "Подготовленное",
+        featurePreparedDesc: "Инструменты для вашего душеприказчика. Папка, которую можно держать в руках. Система, которой можно доверять.",
+
+        // How it works
+        howTitle: "Как это работает",
+        howBeat1Title: "Вы начинаете там, где чувствуете себя комфортно.",
+        howBeat1Desc: "Гид задаёт простые вопросы. Подсказывает, что может быть важным. Вы идёте в своём темпе.",
+        howBeat2Title: "Вы строите со временем.",
+        howBeat2Desc: "Документы. Пожелания. Письма. То, к чему вы готовы. Пропускайте всё, что сегодня не кажется правильным.",
+        howBeat3Title: "Оно открывается, когда нужно.",
+        howBeat3Desc: "Настройте свой Пульс. Подтверждайте время от времени. Если вы перестанете, оно свяжется с людьми, которым вы доверяете—и даст им именно то, что нужно.",
+
+        // Footer
+        footerDisclaimer: "Continuum — это инструмент документирования и организации. Мы не предоставляем юридических, финансовых, налоговых или медицинских консультаций.",
+        footerTagline: "Организованная жизнь. Мягкая передача.",
+
+        // Navigation
+        navHow: "Как это работает",
+        navFeatures: "Возможности",
+        navSecurity: "Безопасность",
+        navLogin: "Войти"
+    },
+
+    he: {
+        // Section 1: The Shoebox
+        heroLine1: "להורים שלכם הייתה קופסת נעליים",
+        heroLine2: "מתחת למיטה.",
+        heroLine3: "לכם יש את Continuum.",
+        heroDesc: "מקום שקט לארגן את החיים שלכם עבור האנשים שאתם אוהבים.",
+
+        // Section 2: The Weight
+        weightTitle: "יום אחד, מישהו יצטרך להבין את החיים שלכם.",
+        weightDesc: "איפה הצוואה? אילו חשבונות קיימים? מה רציתם? הם יהיו באבל. ויחפשו. אלא אם תשאירו להם משהו טוב יותר ממגירה מלאה בשאלות.",
+        weightBridge: "Continuum מוודא שהם לא יהיו לבד כשהיום הזה יגיע.",
+
+        // Section 3: The Guide
+        guideTitle: "אתם לא צריכים לדעת מאיפה להתחיל.",
+        guideDesc: "המדריך של Continuum הולך לצידכם—מציע מה עשוי להיות חשוב, מתרגם את החלקים המבלבלים, עוזר לכם למצוא מילים לדברים שמעולם לא הייתם צריכים לומר.",
+        guideReassurance: "אין סדר נכון. אין שדות חובה. רק הדרכה עדינה, בקצב שלכם.",
+
+        // Section 4: The Pulse
+        pulseTitle: "אתם לא צריכים לנהל את השיחה הקשה.",
+        pulseDesc: "הגדירו את הפולס שלכם. אשרו כל כמה ימים—פשוט \"אני כאן\". ואם יום אחד לא תהיו שם כדי לאשר, Continuum שם לב.",
+        pulseHow: "הוא פונה לאנשים שבחרתם. פותח את הדלתות הנכונות, בזמן הנכון. מנהל העיזבון שלכם לא יתמודד עם תעלומה. הוא יקבל בהירות.",
+        pulseGift: "כבר דאגתם להם. זו הייתה המתנה האחרונה שלכם.",
+
+        // Section 5: The Distinction
+        distinctionTitle: "אנחנו לא עורכי דין או יועצים פיננסיים.",
+        distinctionDesc: "Continuum לא כותב צוואות ולא נותן ייעוץ פיננסי. אנשי המקצוע שלכם עושים את זה.",
+        distinctionRole: "אנחנו שכבת הארגון. אנחנו עוזרים לכם לאסוף את מה שהם יוצרים—ומה שאתם רוצים לומר—כדי שזה יימצא, יובן וישמש.",
+        distinctionTagline: "הם יוצרים את התוכנית. אנחנו מוודאים שהיא עובדת.",
+
+        // Section 6: The Gift
+        giftTitle: "מה הם יקבלו",
+        giftClarity: "בהירות",
+        giftClarityDesc: "הכל מאורגן. אין מה לחפש.",
+        giftGuidance: "הדרכה",
+        giftGuidanceDesc: "עזרה צעד אחר צעד כשהם הכי צריכים.",
+        giftVoice: "הקול שלכם",
+        giftVoiceDesc: "מכתבים, משאלות, הקשר—במילים שלכם.",
+
+        // Section 7: The Invitation
+        invitationTitle: "התחילו כשאתם מוכנים.",
+        invitationDesc: "אין כאן דד-ליין. אין לחץ. חזרו מתי שתרצו.",
+        invitationTagline: "Continuum יחכה.",
+
+        // CTA
+        ctaPrimary: "להתחיל כשאתם מוכנים",
+        ctaExplore: "לגלות מה בפנים",
+
+        // Signup flow
+        signupTitle: "בואו נתחיל בפשטות.",
+        signupNamePrompt: "איך לקרוא לכם?",
+        signupNamePlaceholder: "השם הפרטי שלכם",
+        signupEmailPrompt: "איפה אפשר להגיע אליכם?",
+        signupEmailPlaceholder: "האימייל שלכם",
+        signupButton: "להמשיך",
+        signupWelcome: "ברוכים הבאים,",
+        signupNext: "המרחב שלכם מוכן. קחו את כל הזמן שאתם צריכים.",
+        signupEnter: "להיכנס ל-Continuum",
+        signupBack: "חזרה",
+
+        // Features page
+        featuresTitle: "מה בפנים",
+        featuresIntro: "ל-Continuum עשרות כלים. אתם לא צריכים ללמוד את כולם. התחילו איפה שבא לכם. המדריך לוקח אתכם לאן שצריך.",
+        featurePracticalTitle: "הפרקטי",
+        featurePracticalDesc: "חשבונות. מסמכים. אנשי קשר. הדברים שהם יצטרכו למצוא.",
+        featurePersonalTitle: "האישי",
+        featurePersonalDesc: "מכתבים. חפצי ערך. זיכרונות. הדברים שנושאים משמעות.",
+        featureProtectiveTitle: "המגן",
+        featureProtectiveDesc: "משאלות רפואיות. טיפול בחיות מחמד. הפולס. לוודא שהחיים מטופלים.",
+        featurePreparedTitle: "המוכן",
+        featurePreparedDesc: "כלים עבור מנהל העיזבון שלכם. קלסר שאפשר להחזיק. מערכת שאפשר לסמוך עליה.",
+
+        // How it works
+        howTitle: "איך זה עובד",
+        howBeat1Title: "אתם מתחילים איפה שמרגיש נכון.",
+        howBeat1Desc: "המדריך שואל שאלות פשוטות. מציע מה עשוי להיות חשוב. אתם הולכים בקצב שלכם.",
+        howBeat2Title: "אתם בונים, עם הזמן.",
+        howBeat2Desc: "מסמכים. משאלות. מכתבים. מה שאתם מוכנים אליו. דלגו על כל מה שלא מרגיש נכון היום.",
+        howBeat3Title: "זה נפתח, כשצריך.",
+        howBeat3Desc: "הגדירו את הפולס שלכם. אשרו מדי פעם. אם תפסיקו, זה פונה לאנשים שאתם סומכים עליהם—ונותן להם בדיוק מה שהם צריכים.",
+
+        // Footer
+        footerDisclaimer: "Continuum הוא כלי תיעוד וארגון. איננו מספקים ייעוץ משפטי, פיננסי, מס או רפואי.",
+        footerTagline: "החיים המאורגנים. המסירה העדינה.",
+
+        // Navigation
+        navHow: "איך זה עובד",
+        navFeatures: "תכונות",
+        navSecurity: "אבטחה",
+        navLogin: "כניסה"
+    }
+} as const;
+
+export type Marketing2Language = keyof typeof marketing2Dictionary;
+export type Marketing2Translations = typeof marketing2Dictionary.en;

--- a/frontend/src/lib/stores/marketing2Dictionary.ts
+++ b/frontend/src/lib/stores/marketing2Dictionary.ts
@@ -25,6 +25,11 @@ export const marketing2Dictionary = {
         heroLine3: "You have Continuum.",
         heroDesc: "A calm place to organize your life for the people you love.",
 
+        // Section 1.5: The Kitchen Story (emotional contrast)
+        kitchenTitle: "Picture the kitchen.",
+        kitchenDesc: "After they're gone, you're standing in their kitchen. You don't know where anything is. Which drawer has the insurance papers? Who was their accountant? Did they want to be cremated? The kettle boils. You realize you don't even know where they kept the tea.",
+        kitchenPunchline: "That feeling? You can spare your family from it.",
+
         // Section 2: The Weight
         weightTitle: "Someday, someone will need to figure out your life.",
         weightDesc: "Where's the will? What accounts exist? What did you want? They'll be grieving. And searching. Unless you leave them something better than a drawer full of questions.",
@@ -39,6 +44,7 @@ export const marketing2Dictionary = {
         pulseTitle: "You don't have to have the difficult conversation.",
         pulseDesc: "Set up your Pulse. Check in every few days—a simple \"I'm here.\" And if one day you're not there to check in, Continuum notices.",
         pulseHow: "It reaches out to the people you chose. Opens the right doors, at the right time. Your executor won't face a mystery. They'll receive clarity.",
+        pulseTiers: "Different people see different things, in the order you choose. A trusted friend gets a gentle alert first. Later tiers receive more access. You decide who gets what.",
         pulseGift: "You already took care of them. This was your final gift.",
 
         // Section 5: The Distinction
@@ -46,6 +52,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum doesn't write wills or give financial advice. Your professionals do that.",
         distinctionRole: "We're the organization layer. We help you gather what they create—and what you want to say—so it's found, understood, and used.",
         distinctionTagline: "They create the plan. We make sure it works.",
+
+        // Section 5.5: Security
+        securityTitle: "Your life, protected.",
+        securityDesc: "Everything you store in Continuum is encrypted. Your data stays yours—we can't read it, sell it, or share it.",
+        securityEncryption: "End-to-end encryption",
+        securityEncryptionDesc: "Your information is encrypted before it leaves your device.",
+        securityPrivacy: "No data selling",
+        securityPrivacyDesc: "We make money from subscriptions, not your personal information.",
+        securityControl: "You control access",
+        securityControlDesc: "Choose exactly who sees what, and when.",
 
         // Section 6: The Gift
         giftTitle: "What they'll receive",
@@ -119,6 +135,14 @@ export const marketing2Dictionary = {
         featuresMore: "There's more here than you'll ever need. That's the point. Whatever your situation—complicated family, multiple properties, beloved pets, specific wishes—Continuum has a place for it.",
         featuresMoreSub: "You'll find it when you need it. The guide will take you there.",
 
+        // SEO
+        metaTitle: "Continuum — Organize your life for the people you love",
+        metaDescription: "A calm place to document everything your family will need. Encrypted, private, and ready when the time comes.",
+        metaTitleFeatures: "What's Inside — Continuum",
+        metaDescFeatures: "Explore the tools inside Continuum: practical documents, personal letters, protective systems, and executor preparation.",
+        metaTitleHow: "How It Works — Continuum",
+        metaDescHow: "Three gentle steps: start where feels right, build over time, and let it open when needed.",
+
         // Footer
         footerDisclaimer: "Continuum is a documentation and organization tool. We do not provide legal, financial, tax, or medical advice.",
         footerTagline: "The organized life. The gentle handover.",
@@ -137,6 +161,11 @@ export const marketing2Dictionary = {
         heroLine3: "Tú tienes Continuum.",
         heroDesc: "Un lugar tranquilo para organizar tu vida para las personas que amas.",
 
+        // Section 1.5: The Kitchen Story
+        kitchenTitle: "Imagina la cocina.",
+        kitchenDesc: "Después de que se fueron, estás en su cocina. No sabes dónde está nada. ¿Qué cajón tiene los papeles del seguro? ¿Quién era su contador? ¿Querían ser cremados? La tetera hierve. Te das cuenta de que ni siquiera sabes dónde guardaban el té.",
+        kitchenPunchline: "¿Ese sentimiento? Puedes evitárselo a tu familia.",
+
         // Section 2: The Weight
         weightTitle: "Algún día, alguien tendrá que descifrar tu vida.",
         weightDesc: "¿Dónde está el testamento? ¿Qué cuentas existen? ¿Qué querías? Estarán de duelo. Y buscando. A menos que les dejes algo mejor que un cajón lleno de preguntas.",
@@ -151,6 +180,7 @@ export const marketing2Dictionary = {
         pulseTitle: "No tienes que tener la conversación difícil.",
         pulseDesc: "Configura tu Pulso. Confirma cada pocos días—un simple \"Estoy aquí.\" Y si un día no estás para confirmar, Continuum lo nota.",
         pulseHow: "Se comunica con las personas que elegiste. Abre las puertas correctas, en el momento correcto. Tu albacea no enfrentará un misterio. Recibirá claridad.",
+        pulseTiers: "Diferentes personas ven diferentes cosas, en el orden que tú elijas. Un amigo de confianza recibe una alerta suave primero. Los niveles posteriores reciben más acceso. Tú decides quién recibe qué.",
         pulseGift: "Ya cuidaste de ellos. Este fue tu último regalo.",
 
         // Section 5: The Distinction
@@ -158,6 +188,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum no redacta testamentos ni da asesoramiento financiero. Tus profesionales hacen eso.",
         distinctionRole: "Somos la capa de organización. Te ayudamos a reunir lo que ellos crean—y lo que quieres decir—para que se encuentre, se entienda y se use.",
         distinctionTagline: "Ellos crean el plan. Nosotros nos aseguramos de que funcione.",
+
+        // Section 5.5: Security
+        securityTitle: "Tu vida, protegida.",
+        securityDesc: "Todo lo que almacenas en Continuum está cifrado. Tus datos son tuyos—no podemos leerlos, venderlos ni compartirlos.",
+        securityEncryption: "Cifrado de extremo a extremo",
+        securityEncryptionDesc: "Tu información se cifra antes de salir de tu dispositivo.",
+        securityPrivacy: "No vendemos datos",
+        securityPrivacyDesc: "Ganamos dinero con suscripciones, no con tu información personal.",
+        securityControl: "Tú controlas el acceso",
+        securityControlDesc: "Elige exactamente quién ve qué, y cuándo.",
 
         // Section 6: The Gift
         giftTitle: "Lo que recibirán",
@@ -231,6 +271,14 @@ export const marketing2Dictionary = {
         featuresMore: "Hay más aquí de lo que jamás necesitarás. Ese es el punto. Sea cual sea tu situación—familia complicada, múltiples propiedades, mascotas queridas, deseos específicos—Continuum tiene un lugar para ello.",
         featuresMoreSub: "Lo encontrarás cuando lo necesites. La guía te llevará allí.",
 
+        // SEO
+        metaTitle: "Continuum — Organiza tu vida para las personas que amas",
+        metaDescription: "Un lugar tranquilo para documentar todo lo que tu familia necesitará. Cifrado, privado y listo cuando llegue el momento.",
+        metaTitleFeatures: "Lo que hay dentro — Continuum",
+        metaDescFeatures: "Explora las herramientas dentro de Continuum: documentos prácticos, cartas personales, sistemas de protección y preparación para el albacea.",
+        metaTitleHow: "Cómo funciona — Continuum",
+        metaDescHow: "Tres pasos amables: empieza donde te sientas cómodo, construye con el tiempo, y deja que se abra cuando sea necesario.",
+
         // Footer
         footerDisclaimer: "Continuum es una herramienta de documentación y organización. No proporcionamos asesoramiento legal, financiero, fiscal o médico.",
         footerTagline: "La vida organizada. La entrega gentil.",
@@ -249,6 +297,11 @@ export const marketing2Dictionary = {
         heroLine3: "Vous avez Continuum.",
         heroDesc: "Un espace serein pour organiser votre vie pour ceux que vous aimez.",
 
+        // Section 1.5: The Kitchen Story
+        kitchenTitle: "Imaginez la cuisine.",
+        kitchenDesc: "Après leur départ, vous êtes dans leur cuisine. Vous ne savez pas où se trouve quoi que ce soit. Quel tiroir contient les papiers d'assurance ? Qui était leur comptable ? Voulaient-ils être incinérés ? La bouilloire chauffe. Vous réalisez que vous ne savez même pas où ils rangeaient le thé.",
+        kitchenPunchline: "Ce sentiment ? Vous pouvez l'épargner à votre famille.",
+
         // Section 2: The Weight
         weightTitle: "Un jour, quelqu'un devra comprendre votre vie.",
         weightDesc: "Où est le testament ? Quels comptes existent ? Que vouliez-vous ? Ils seront en deuil. Et à la recherche. À moins que vous ne leur laissiez quelque chose de mieux qu'un tiroir plein de questions.",
@@ -263,6 +316,7 @@ export const marketing2Dictionary = {
         pulseTitle: "Vous n'avez pas besoin d'avoir la conversation difficile.",
         pulseDesc: "Configurez votre Pulse. Confirmez tous les quelques jours—un simple « Je suis là ». Et si un jour vous n'êtes pas là pour confirmer, Continuum le remarque.",
         pulseHow: "Il contacte les personnes que vous avez choisies. Ouvre les bonnes portes, au bon moment. Votre exécuteur ne fera pas face à un mystère. Il recevra de la clarté.",
+        pulseTiers: "Différentes personnes voient différentes choses, dans l'ordre que vous choisissez. Un ami de confiance reçoit d'abord une alerte douce. Les niveaux suivants reçoivent plus d'accès. Vous décidez qui reçoit quoi.",
         pulseGift: "Vous avez déjà pris soin d'eux. C'était votre dernier cadeau.",
 
         // Section 5: The Distinction
@@ -270,6 +324,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum ne rédige pas de testaments et ne donne pas de conseils financiers. Vos professionnels font cela.",
         distinctionRole: "Nous sommes la couche d'organisation. Nous vous aidons à rassembler ce qu'ils créent—et ce que vous voulez dire—pour que cela soit trouvé, compris et utilisé.",
         distinctionTagline: "Ils créent le plan. Nous nous assurons qu'il fonctionne.",
+
+        // Section 5.5: Security
+        securityTitle: "Votre vie, protégée.",
+        securityDesc: "Tout ce que vous stockez dans Continuum est chiffré. Vos données restent les vôtres—nous ne pouvons ni les lire, ni les vendre, ni les partager.",
+        securityEncryption: "Chiffrement de bout en bout",
+        securityEncryptionDesc: "Vos informations sont chiffrées avant de quitter votre appareil.",
+        securityPrivacy: "Pas de vente de données",
+        securityPrivacyDesc: "Nous gagnons de l'argent avec les abonnements, pas avec vos informations personnelles.",
+        securityControl: "Vous contrôlez l'accès",
+        securityControlDesc: "Choisissez exactement qui voit quoi, et quand.",
 
         // Section 6: The Gift
         giftTitle: "Ce qu'ils recevront",
@@ -343,6 +407,14 @@ export const marketing2Dictionary = {
         featuresMore: "Il y a plus ici que vous n'en aurez jamais besoin. C'est le but. Quelle que soit votre situation—famille compliquée, propriétés multiples, animaux de compagnie adorés, souhaits spécifiques—Continuum a une place pour cela.",
         featuresMoreSub: "Vous le trouverez quand vous en aurez besoin. Le guide vous y mènera.",
 
+        // SEO
+        metaTitle: "Continuum — Organisez votre vie pour ceux que vous aimez",
+        metaDescription: "Un espace serein pour documenter tout ce dont votre famille aura besoin. Chiffré, privé et prêt le moment venu.",
+        metaTitleFeatures: "Ce qu'il y a à l'intérieur — Continuum",
+        metaDescFeatures: "Découvrez les outils de Continuum : documents pratiques, lettres personnelles, systèmes de protection et préparation pour l'exécuteur.",
+        metaTitleHow: "Comment ça marche — Continuum",
+        metaDescHow: "Trois étapes douces : commencez où vous vous sentez à l'aise, construisez au fil du temps, et laissez-le s'ouvrir quand c'est nécessaire.",
+
         // Footer
         footerDisclaimer: "Continuum est un outil de documentation et d'organisation. Nous ne fournissons pas de conseils juridiques, financiers, fiscaux ou médicaux.",
         footerTagline: "La vie organisée. La transmission douce.",
@@ -361,6 +433,11 @@ export const marketing2Dictionary = {
         heroLine3: "Sie haben Continuum.",
         heroDesc: "Ein ruhiger Ort, um Ihr Leben für die Menschen zu organisieren, die Sie lieben.",
 
+        // Section 1.5: The Kitchen Story
+        kitchenTitle: "Stellen Sie sich die Küche vor.",
+        kitchenDesc: "Nachdem sie gegangen sind, stehen Sie in ihrer Küche. Sie wissen nicht, wo irgendetwas ist. In welcher Schublade sind die Versicherungspapiere? Wer war ihr Buchhalter? Wollten sie eingeäschert werden? Der Wasserkocher kocht. Sie merken, dass Sie nicht einmal wissen, wo sie den Tee aufbewahrt haben.",
+        kitchenPunchline: "Dieses Gefühl? Sie können es Ihrer Familie ersparen.",
+
         // Section 2: The Weight
         weightTitle: "Eines Tages wird jemand Ihr Leben verstehen müssen.",
         weightDesc: "Wo ist das Testament? Welche Konten gibt es? Was wollten Sie? Sie werden trauern. Und suchen. Es sei denn, Sie hinterlassen ihnen etwas Besseres als eine Schublade voller Fragen.",
@@ -375,6 +452,7 @@ export const marketing2Dictionary = {
         pulseTitle: "Sie müssen das schwierige Gespräch nicht führen.",
         pulseDesc: "Richten Sie Ihren Puls ein. Bestätigen Sie alle paar Tage—ein einfaches „Ich bin hier." Und wenn Sie eines Tages nicht da sind, um zu bestätigen, bemerkt es Continuum.",
         pulseHow: "Es wendet sich an die Menschen, die Sie gewählt haben. Öffnet die richtigen Türen, zur richtigen Zeit. Ihr Testamentsvollstrecker steht nicht vor einem Rätsel. Er erhält Klarheit.",
+        pulseTiers: "Verschiedene Personen sehen verschiedene Dinge, in der Reihenfolge, die Sie wählen. Ein vertrauter Freund erhält zuerst eine sanfte Benachrichtigung. Spätere Stufen erhalten mehr Zugang. Sie entscheiden, wer was bekommt.",
         pulseGift: "Sie haben bereits für sie gesorgt. Das war Ihr letztes Geschenk.",
 
         // Section 5: The Distinction
@@ -382,6 +460,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum verfasst keine Testamente und gibt keine Finanzberatung. Das machen Ihre Fachleute.",
         distinctionRole: "Wir sind die Organisationsebene. Wir helfen Ihnen, das zu sammeln, was sie erstellen—und was Sie sagen möchten—damit es gefunden, verstanden und verwendet wird.",
         distinctionTagline: "Sie erstellen den Plan. Wir sorgen dafür, dass er funktioniert.",
+
+        // Section 5.5: Security
+        securityTitle: "Ihr Leben, geschützt.",
+        securityDesc: "Alles, was Sie in Continuum speichern, ist verschlüsselt. Ihre Daten gehören Ihnen—wir können sie nicht lesen, verkaufen oder teilen.",
+        securityEncryption: "Ende-zu-Ende-Verschlüsselung",
+        securityEncryptionDesc: "Ihre Informationen werden verschlüsselt, bevor sie Ihr Gerät verlassen.",
+        securityPrivacy: "Kein Datenverkauf",
+        securityPrivacyDesc: "Wir verdienen Geld mit Abonnements, nicht mit Ihren persönlichen Daten.",
+        securityControl: "Sie kontrollieren den Zugang",
+        securityControlDesc: "Wählen Sie genau aus, wer was sieht und wann.",
 
         // Section 6: The Gift
         giftTitle: "Was sie erhalten werden",
@@ -455,6 +543,14 @@ export const marketing2Dictionary = {
         featuresMore: "Es gibt hier mehr, als Sie jemals brauchen werden. Das ist der Punkt. Was auch immer Ihre Situation ist—komplizierte Familie, mehrere Immobilien, geliebte Haustiere, spezielle Wünsche—Continuum hat einen Platz dafür.",
         featuresMoreSub: "Sie werden es finden, wenn Sie es brauchen. Der Leitfaden bringt Sie dorthin.",
 
+        // SEO
+        metaTitle: "Continuum — Organisieren Sie Ihr Leben für die Menschen, die Sie lieben",
+        metaDescription: "Ein ruhiger Ort, um alles zu dokumentieren, was Ihre Familie brauchen wird. Verschlüsselt, privat und bereit, wenn die Zeit kommt.",
+        metaTitleFeatures: "Was drin ist — Continuum",
+        metaDescFeatures: "Entdecken Sie die Werkzeuge in Continuum: praktische Dokumente, persönliche Briefe, Schutzsysteme und Vorbereitung für den Testamentsvollstrecker.",
+        metaTitleHow: "So funktioniert es — Continuum",
+        metaDescHow: "Drei sanfte Schritte: Beginnen Sie, wo es sich richtig anfühlt, bauen Sie mit der Zeit auf, und lassen Sie es sich öffnen, wenn nötig.",
+
         // Footer
         footerDisclaimer: "Continuum ist ein Dokumentations- und Organisationswerkzeug. Wir bieten keine rechtliche, finanzielle, steuerliche oder medizinische Beratung.",
         footerTagline: "Das organisierte Leben. Die sanfte Übergabe.",
@@ -473,6 +569,11 @@ export const marketing2Dictionary = {
         heroLine3: "У вас есть Continuum.",
         heroDesc: "Спокойное место для организации вашей жизни для тех, кого вы любите.",
 
+        // Section 1.5: The Kitchen Story
+        kitchenTitle: "Представьте кухню.",
+        kitchenDesc: "После их ухода вы стоите на их кухне. Вы не знаете, где что лежит. В каком ящике страховые документы? Кто был их бухгалтером? Хотели ли они быть кремированы? Чайник кипит. Вы понимаете, что даже не знаете, где они хранили чай.",
+        kitchenPunchline: "Это чувство? Вы можете избавить от него свою семью.",
+
         // Section 2: The Weight
         weightTitle: "Когда-нибудь кому-то придётся разобраться в вашей жизни.",
         weightDesc: "Где завещание? Какие счета существуют? Чего вы хотели? Они будут горевать. И искать. Если только вы не оставите им что-то лучшее, чем ящик, полный вопросов.",
@@ -487,6 +588,7 @@ export const marketing2Dictionary = {
         pulseTitle: "Вам не нужно вести трудный разговор.",
         pulseDesc: "Настройте свой Пульс. Подтверждайте каждые несколько дней—простое «Я здесь». И если однажды вас не будет, чтобы подтвердить, Continuum это заметит.",
         pulseHow: "Он связывается с людьми, которых вы выбрали. Открывает нужные двери в нужное время. Ваш душеприказчик не столкнётся с загадкой. Он получит ясность.",
+        pulseTiers: "Разные люди видят разное, в том порядке, который вы выберете. Доверенный друг получит мягкое уведомление первым. Следующие уровни получат больше доступа. Вы решаете, кто что получит.",
         pulseGift: "Вы уже позаботились о них. Это был ваш последний подарок.",
 
         // Section 5: The Distinction
@@ -494,6 +596,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum не составляет завещания и не даёт финансовых советов. Этим занимаются ваши специалисты.",
         distinctionRole: "Мы — уровень организации. Мы помогаем вам собрать то, что они создают—и то, что вы хотите сказать—чтобы это было найдено, понято и использовано.",
         distinctionTagline: "Они создают план. Мы следим за тем, чтобы он работал.",
+
+        // Section 5.5: Security
+        securityTitle: "Ваша жизнь под защитой.",
+        securityDesc: "Всё, что вы храните в Continuum, зашифровано. Ваши данные остаются вашими—мы не можем их читать, продавать или передавать.",
+        securityEncryption: "Сквозное шифрование",
+        securityEncryptionDesc: "Ваша информация шифруется до того, как покинет ваше устройство.",
+        securityPrivacy: "Никакой продажи данных",
+        securityPrivacyDesc: "Мы зарабатываем на подписках, а не на вашей личной информации.",
+        securityControl: "Вы контролируете доступ",
+        securityControlDesc: "Выбирайте, кто именно что видит и когда.",
 
         // Section 6: The Gift
         giftTitle: "Что они получат",
@@ -567,6 +679,14 @@ export const marketing2Dictionary = {
         featuresMore: "Здесь больше, чем вам когда-либо понадобится. В этом и смысл. Какова бы ни была ваша ситуация—сложная семья, несколько объектов недвижимости, любимые питомцы, особые пожелания—в Continuum есть место для всего.",
         featuresMoreSub: "Вы найдёте это, когда понадобится. Гид приведёт вас туда.",
 
+        // SEO
+        metaTitle: "Continuum — Организуйте свою жизнь для тех, кого вы любите",
+        metaDescription: "Спокойное место для документирования всего, что понадобится вашей семье. Зашифровано, конфиденциально и готово, когда придёт время.",
+        metaTitleFeatures: "Что внутри — Continuum",
+        metaDescFeatures: "Исследуйте инструменты Continuum: практичные документы, личные письма, защитные системы и подготовка для душеприказчика.",
+        metaTitleHow: "Как это работает — Continuum",
+        metaDescHow: "Три мягких шага: начните там, где чувствуете себя комфортно, стройте со временем, и позвольте ему открыться, когда нужно.",
+
         // Footer
         footerDisclaimer: "Continuum — это инструмент документирования и организации. Мы не предоставляем юридических, финансовых, налоговых или медицинских консультаций.",
         footerTagline: "Организованная жизнь. Мягкая передача.",
@@ -585,6 +705,11 @@ export const marketing2Dictionary = {
         heroLine3: "לכם יש את Continuum.",
         heroDesc: "מקום שקט לארגן את החיים שלכם עבור האנשים שאתם אוהבים.",
 
+        // Section 1.5: The Kitchen Story
+        kitchenTitle: "דמיינו את המטבח.",
+        kitchenDesc: "אחרי שהם הלכו, אתם עומדים במטבח שלהם. אתם לא יודעים איפה שום דבר. באיזו מגירה יש את מסמכי הביטוח? מי היה רואה החשבון שלהם? האם הם רצו להישרף? הקומקום רותח. אתם מבינים שאתם אפילו לא יודעים איפה הם שמרו את התה.",
+        kitchenPunchline: "ההרגשה הזו? אתם יכולים לחסוך אותה מהמשפחה שלכם.",
+
         // Section 2: The Weight
         weightTitle: "יום אחד, מישהו יצטרך להבין את החיים שלכם.",
         weightDesc: "איפה הצוואה? אילו חשבונות קיימים? מה רציתם? הם יהיו באבל. ויחפשו. אלא אם תשאירו להם משהו טוב יותר ממגירה מלאה בשאלות.",
@@ -599,6 +724,7 @@ export const marketing2Dictionary = {
         pulseTitle: "אתם לא צריכים לנהל את השיחה הקשה.",
         pulseDesc: "הגדירו את הפולס שלכם. אשרו כל כמה ימים—פשוט \"אני כאן\". ואם יום אחד לא תהיו שם כדי לאשר, Continuum שם לב.",
         pulseHow: "הוא פונה לאנשים שבחרתם. פותח את הדלתות הנכונות, בזמן הנכון. מנהל העיזבון שלכם לא יתמודד עם תעלומה. הוא יקבל בהירות.",
+        pulseTiers: "אנשים שונים רואים דברים שונים, בסדר שאתם בוחרים. חבר מהימן מקבל התראה עדינה קודם. הרמות הבאות מקבלות יותר גישה. אתם מחליטים מי מקבל מה.",
         pulseGift: "כבר דאגתם להם. זו הייתה המתנה האחרונה שלכם.",
 
         // Section 5: The Distinction
@@ -606,6 +732,16 @@ export const marketing2Dictionary = {
         distinctionDesc: "Continuum לא כותב צוואות ולא נותן ייעוץ פיננסי. אנשי המקצוע שלכם עושים את זה.",
         distinctionRole: "אנחנו שכבת הארגון. אנחנו עוזרים לכם לאסוף את מה שהם יוצרים—ומה שאתם רוצים לומר—כדי שזה יימצא, יובן וישמש.",
         distinctionTagline: "הם יוצרים את התוכנית. אנחנו מוודאים שהיא עובדת.",
+
+        // Section 5.5: Security
+        securityTitle: "החיים שלכם, מוגנים.",
+        securityDesc: "כל מה שאתם שומרים ב-Continuum מוצפן. המידע שלכם נשאר שלכם—אנחנו לא יכולים לקרוא אותו, למכור אותו או לשתף אותו.",
+        securityEncryption: "הצפנה מקצה לקצה",
+        securityEncryptionDesc: "המידע שלכם מוצפן לפני שהוא עוזב את המכשיר שלכם.",
+        securityPrivacy: "ללא מכירת נתונים",
+        securityPrivacyDesc: "אנחנו מרוויחים כסף מהנויים, לא מהמידע האישי שלכם.",
+        securityControl: "אתם שולטים בגישה",
+        securityControlDesc: "בחרו בדיוק מי רואה מה, ומתי.",
 
         // Section 6: The Gift
         giftTitle: "מה הם יקבלו",
@@ -678,6 +814,14 @@ export const marketing2Dictionary = {
         preparedItem4: "סימולטור ניסיון",
         featuresMore: "יש כאן יותר ממה שתצטרכו אי פעם. זו הנקודה. לא משנה מה המצב שלכם—משפחה מסובכת, נכסים מרובים, חיות מחמד אהובות, משאלות ספציפיות—ל-Continuum יש מקום לזה.",
         featuresMoreSub: "תמצאו את זה כשתצטרכו. המדריך ייקח אתכם לשם.",
+
+        // SEO
+        metaTitle: "Continuum — ארגנו את החיים שלכם עבור האנשים שאתם אוהבים",
+        metaDescription: "מקום שקט לתעד את כל מה שהמשפחה שלכם תצטרך. מוצפן, פרטי ומוכן כשיגיע הזמן.",
+        metaTitleFeatures: "מה בפנים — Continuum",
+        metaDescFeatures: "גלו את הכלים בתוך Continuum: מסמכים פרקטיים, מכתבים אישיים, מערכות הגנה והכנה למנהל העיזבון.",
+        metaTitleHow: "איך זה עובד — Continuum",
+        metaDescHow: "שלושה צעדים עדינים: התחילו איפה שמרגיש נכון, בנו עם הזמן, ותנו לזה להיפתח כשצריך.",
 
         // Footer
         footerDisclaimer: "Continuum הוא כלי תיעוד וארגון. איננו מספקים ייעוץ משפטי, פיננסי, מס או רפואי.",

--- a/frontend/src/routes/marketing2/+layout.svelte
+++ b/frontend/src/routes/marketing2/+layout.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+    import { onNavigate } from "$app/navigation";
+    import { fade } from "svelte/transition";
+    import { cubicOut } from "svelte/easing";
+
+    let { children } = $props();
+
+    // Page transition with View Transitions API fallback
+    onNavigate((navigation) => {
+        // Check if View Transitions API is supported
+        if (!document.startViewTransition) return;
+
+        return new Promise((resolve) => {
+            document.startViewTransition(async () => {
+                resolve();
+                await navigation.complete;
+            });
+        });
+    });
+</script>
+
+<!-- Global styles for View Transitions -->
+<svelte:head>
+    <style>
+        /* View Transition animations */
+        @keyframes fade-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @keyframes fade-out {
+            from { opacity: 1; }
+            to { opacity: 0; }
+        }
+
+        @keyframes slide-from-right {
+            from { transform: translateX(30px); opacity: 0; }
+            to { transform: translateX(0); opacity: 1; }
+        }
+
+        @keyframes slide-to-left {
+            from { transform: translateX(0); opacity: 1; }
+            to { transform: translateX(-30px); opacity: 0; }
+        }
+
+        ::view-transition-old(root) {
+            animation: 300ms cubic-bezier(0.4, 0, 0.2, 1) both fade-out,
+                       300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+        }
+
+        ::view-transition-new(root) {
+            animation: 300ms cubic-bezier(0.4, 0, 0.2, 1) both fade-in,
+                       300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+        }
+
+        /* Reduce motion if preferred */
+        @media (prefers-reduced-motion: reduce) {
+            ::view-transition-old(root),
+            ::view-transition-new(root) {
+                animation: none;
+            }
+        }
+    </style>
+</svelte:head>
+
+<div class="page-wrapper" in:fade={{ duration: 200, easing: cubicOut }}>
+    {@render children()}
+</div>
+
+<style>
+    .page-wrapper {
+        min-height: 100vh;
+    }
+</style>

--- a/frontend/src/routes/marketing2/+page.svelte
+++ b/frontend/src/routes/marketing2/+page.svelte
@@ -11,7 +11,10 @@
         Heart,
         Compass,
         Shield,
-        BookOpen
+        BookOpen,
+        Menu,
+        X,
+        Lock
     } from "lucide-svelte";
     import {
         keyringEmails,
@@ -24,6 +27,7 @@
     let innerHeight = $state(0);
     let introVisible = $state(false);
     let langMenuOpen = $state(false);
+    let mobileMenuOpen = $state(false);
 
     // Signup flow state
     let name = $state("");
@@ -82,6 +86,17 @@
     const heroOpacity = $derived(Math.max(0, 1 - scrollY / (innerHeight * 0.5)));
 </script>
 
+<svelte:head>
+    <title>{$m2t.metaTitle}</title>
+    <meta name="description" content={$m2t.metaDescription} />
+    <meta property="og:title" content={$m2t.metaTitle} />
+    <meta property="og:description" content={$m2t.metaDescription} />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={$m2t.metaTitle} />
+    <meta name="twitter:description" content={$m2t.metaDescription} />
+</svelte:head>
+
 <svelte:window bind:scrollY bind:innerHeight />
 
 <div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
@@ -113,6 +128,19 @@
 
             <!-- Right side -->
             <div class="flex items-center gap-4">
+                <!-- Mobile menu button -->
+                <button
+                    onclick={() => mobileMenuOpen = !mobileMenuOpen}
+                    class="md:hidden text-white/60 hover:text-white transition-colors p-2"
+                    aria-label="Toggle menu"
+                >
+                    {#if mobileMenuOpen}
+                        <X size={24} />
+                    {:else}
+                        <Menu size={24} />
+                    {/if}
+                </button>
+
                 <!-- Language selector -->
                 <div class="relative">
                     <button
@@ -152,6 +180,38 @@
                 </a>
             </div>
         </div>
+
+        <!-- Mobile menu -->
+        {#if mobileMenuOpen}
+            <div
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
+                transition:fade={{ duration: 150 }}
+            >
+                <nav class="flex flex-col px-6 py-4 space-y-4">
+                    <a
+                        href="/marketing2/how"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navHow}
+                    </a>
+                    <a
+                        href="/marketing2/features"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navFeatures}
+                    </a>
+                    <a
+                        href="#security"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navSecurity}
+                    </a>
+                </nav>
+            </div>
+        {/if}
     </header>
 
     <main class="relative z-10">
@@ -175,9 +235,16 @@
                         <p class="text-2xl md:text-3xl font-serif text-amber-400/90 mb-8">
                             {$m2t.heroLine3}
                         </p>
-                        <p class="text-lg text-white/50 max-w-xl mx-auto">
+                        <p class="text-lg text-white/50 max-w-xl mx-auto mb-10">
                             {$m2t.heroDesc}
                         </p>
+                        <a
+                            href="/marketing2/features"
+                            class="inline-flex items-center gap-2 text-sm text-white/40 hover:text-white/60 transition-colors"
+                        >
+                            {$m2t.ctaExplore}
+                            <ArrowRight size={16} />
+                        </a>
                     </div>
                 {/if}
             </div>
@@ -185,6 +252,21 @@
             <!-- Scroll indicator -->
             <div class="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3 text-white/30" style="opacity: {heroOpacity};">
                 <div class="w-px h-12 bg-gradient-to-b from-white/20 to-transparent"></div>
+            </div>
+        </section>
+
+        <!-- Section 1.5: The Kitchen Story -->
+        <section class="py-24 px-6 bg-gradient-to-b from-transparent via-rose-950/5 to-transparent">
+            <div class="max-w-2xl mx-auto reveal-section" use:reveal>
+                <h2 class="text-2xl md:text-3xl font-serif text-white/80 text-center mb-10">
+                    {$m2t.kitchenTitle}
+                </h2>
+                <p class="text-lg text-white/40 leading-relaxed mb-10 italic">
+                    {$m2t.kitchenDesc}
+                </p>
+                <p class="text-xl text-rose-400/70 font-serif text-center">
+                    {$m2t.kitchenPunchline}
+                </p>
             </div>
         </section>
 
@@ -240,6 +322,9 @@
                     <p class="text-lg text-white/50 leading-relaxed">
                         {$m2t.pulseHow}
                     </p>
+                    <p class="text-base text-white/40 leading-relaxed">
+                        {$m2t.pulseTiers}
+                    </p>
                     <p class="text-xl text-teal-400/80 font-serif italic">
                         {$m2t.pulseGift}
                     </p>
@@ -248,7 +333,7 @@
         </section>
 
         <!-- Section 5: The Distinction -->
-        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent" id="security">
+        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent">
             <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
                 <div class="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mx-auto mb-8">
                     <Shield size={24} class="text-white/50" />
@@ -265,6 +350,38 @@
                 <p class="text-lg text-white/60 font-serif italic">
                     {$m2t.distinctionTagline}
                 </p>
+            </div>
+        </section>
+
+        <!-- Section 5.5: Security -->
+        <section class="py-32 px-6" id="security">
+            <div class="max-w-4xl mx-auto reveal-section" use:reveal>
+                <div class="text-center mb-16">
+                    <div class="w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center mx-auto mb-8">
+                        <Lock size={24} class="text-emerald-400/70" />
+                    </div>
+                    <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-6">
+                        {$m2t.securityTitle}
+                    </h2>
+                    <p class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto">
+                        {$m2t.securityDesc}
+                    </p>
+                </div>
+
+                <div class="grid md:grid-cols-3 gap-8">
+                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityEncryption}</h3>
+                        <p class="text-sm text-white/40">{$m2t.securityEncryptionDesc}</p>
+                    </div>
+                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityPrivacy}</h3>
+                        <p class="text-sm text-white/40">{$m2t.securityPrivacyDesc}</p>
+                    </div>
+                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityControl}</h3>
+                        <p class="text-sm text-white/40">{$m2t.securityControlDesc}</p>
+                    </div>
+                </div>
             </div>
         </section>
 
@@ -389,13 +506,20 @@
 
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-white/5">
-        <div class="max-w-4xl mx-auto text-center space-y-4">
-            <p class="text-xs text-white/30">
-                {$m2t.footerDisclaimer}
-            </p>
-            <p class="text-sm text-white/20 font-serif italic">
-                {$m2t.footerTagline}
-            </p>
+        <div class="max-w-4xl mx-auto">
+            <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
+                <a href="/marketing2/how" class="hover:text-white/60 transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="hover:text-white/60 transition-colors">{$m2t.navFeatures}</a>
+                <a href="#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+            <div class="text-center space-y-4">
+                <p class="text-xs text-white/30">
+                    {$m2t.footerDisclaimer}
+                </p>
+                <p class="text-sm text-white/20 font-serif italic">
+                    {$m2t.footerTagline}
+                </p>
+            </div>
         </div>
     </footer>
 </div>

--- a/frontend/src/routes/marketing2/+page.svelte
+++ b/frontend/src/routes/marketing2/+page.svelte
@@ -106,8 +106,8 @@
 
             <!-- Nav -->
             <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
-                <a href="#how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
-                <a href="#features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
+                <a href="/marketing2/how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
                 <a href="#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
             </nav>
 

--- a/frontend/src/routes/marketing2/+page.svelte
+++ b/frontend/src/routes/marketing2/+page.svelte
@@ -1,0 +1,420 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { fade, fly, scale } from "svelte/transition";
+    import { cubicOut } from "svelte/easing";
+    import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
+    import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
+    import {
+        ArrowRight,
+        ChevronDown,
+        Globe,
+        Heart,
+        Compass,
+        Shield,
+        BookOpen
+    } from "lucide-svelte";
+    import {
+        keyringEmails,
+        registerAccount,
+        switchAccount,
+    } from "$lib/stores/keyringStore";
+    import { get } from "svelte/store";
+
+    let scrollY = $state(0);
+    let innerHeight = $state(0);
+    let introVisible = $state(false);
+    let langMenuOpen = $state(false);
+
+    // Signup flow state
+    let name = $state("");
+    let email = $state("");
+    let signupStep = $state(0); // 0: name, 1: email, 2: welcome
+
+    // Intersection observer for reveal animations
+    function reveal(node: HTMLElement) {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        node.classList.add("revealed");
+                    }
+                });
+            },
+            { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
+        );
+        observer.observe(node);
+        return { destroy: () => observer.disconnect() };
+    }
+
+    onMount(() => {
+        // Scroll to top on mount
+        window.scrollTo(0, 0);
+        setTimeout(() => (introVisible = true), 300);
+    });
+
+    function handleNameSubmit() {
+        if (name.trim().length > 1) {
+            signupStep = 1;
+        }
+    }
+
+    function handleEmailSubmit() {
+        if (email.includes("@") && email.includes(".")) {
+            const existingEmails = get(keyringEmails);
+            if (existingEmails.includes(email)) {
+                switchAccount(email);
+                return;
+            }
+            registerAccount(email);
+            import("$lib/stores/persistence").then((m) => {
+                m.setStored("owner", { name: name.trim(), id: "owner" });
+            });
+            signupStep = 2;
+        }
+    }
+
+    function setLanguage(lang: Marketing2Language) {
+        m2Language.set(lang);
+        langMenuOpen = false;
+    }
+
+    // Computed scroll progress for hero
+    const heroOpacity = $derived(Math.max(0, 1 - scrollY / (innerHeight * 0.5)));
+</script>
+
+<svelte:window bind:scrollY bind:innerHeight />
+
+<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Subtle Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none">
+        <!-- Gradient overlay -->
+        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+        <!-- Subtle grain -->
+        <div
+            class="absolute inset-0 opacity-[0.03]"
+            style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\"0 0 256 256\" xmlns=\"http://www.w3.org/2000/svg\"%3E%3Cfilter id=\"noise\"%3E%3CfeTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" numOctaves=\"4\" stitchTiles=\"stitch\"/%3E%3C/filter%3E%3Crect width=\"100%25\" height=\"100%25\" filter=\"url(%23noise)\"/%3E%3C/svg%3E');"
+        ></div>
+    </div>
+
+    <!-- Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 transition-all duration-500" class:bg-black/80={scrollY > 100} class:backdrop-blur-md={scrollY > 100}>
+        <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+            <!-- Logo -->
+            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+                Continuum
+            </a>
+
+            <!-- Nav -->
+            <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
+                <a href="#how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
+                <a href="#features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
+                <a href="#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+
+            <!-- Right side -->
+            <div class="flex items-center gap-4">
+                <!-- Language selector -->
+                <div class="relative">
+                    <button
+                        onclick={() => langMenuOpen = !langMenuOpen}
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                    >
+                        <Globe size={16} />
+                        <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
+                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                    </button>
+
+                    {#if langMenuOpen}
+                        <div
+                            class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
+                            transition:fade={{ duration: 150 }}
+                        >
+                            {#each availableLanguages as lang}
+                                <button
+                                    onclick={() => setLanguage(lang.code as Marketing2Language)}
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class:text-amber-400={$m2Language === lang.code}
+                                    class:text-white/70={$m2Language !== lang.code}
+                                >
+                                    {lang.native}
+                                </button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+
+                <!-- Login -->
+                <a
+                    href="/login"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                >
+                    {$m2t.navLogin}
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <main class="relative z-10">
+        <!-- Section 1: The Shoebox (Hero) -->
+        <section class="min-h-screen flex items-center justify-center px-6 relative">
+            <div
+                class="text-center max-w-3xl mx-auto"
+                style="opacity: {heroOpacity}; transform: translateY({scrollY * 0.1}px);"
+            >
+                {#if introVisible}
+                    <div class="space-y-4 mb-8" in:fade={{ duration: 800, delay: 200 }}>
+                        <h1 class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/90 leading-tight">
+                            {$m2t.heroLine1}
+                        </h1>
+                        <h1 class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/60 leading-tight">
+                            {$m2t.heroLine2}
+                        </h1>
+                    </div>
+
+                    <div in:fade={{ duration: 800, delay: 600 }}>
+                        <p class="text-2xl md:text-3xl font-serif text-amber-400/90 mb-8">
+                            {$m2t.heroLine3}
+                        </p>
+                        <p class="text-lg text-white/50 max-w-xl mx-auto">
+                            {$m2t.heroDesc}
+                        </p>
+                    </div>
+                {/if}
+            </div>
+
+            <!-- Scroll indicator -->
+            <div class="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3 text-white/30" style="opacity: {heroOpacity};">
+                <div class="w-px h-12 bg-gradient-to-b from-white/20 to-transparent"></div>
+            </div>
+        </section>
+
+        <!-- Section 2: The Weight -->
+        <section class="py-32 px-6">
+            <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
+                <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8 leading-relaxed">
+                    {$m2t.weightTitle}
+                </h2>
+                <p class="text-lg text-white/50 leading-relaxed mb-12">
+                    {$m2t.weightDesc}
+                </p>
+                <p class="text-xl text-amber-400/80 font-serif italic">
+                    {$m2t.weightBridge}
+                </p>
+            </div>
+        </section>
+
+        <!-- Section 3: The Guide -->
+        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-amber-950/5 to-transparent">
+            <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
+                <div class="w-12 h-12 rounded-full bg-amber-500/10 flex items-center justify-center mx-auto mb-8">
+                    <Compass size={24} class="text-amber-400/70" />
+                </div>
+                <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8">
+                    {$m2t.guideTitle}
+                </h2>
+                <p class="text-lg text-white/50 leading-relaxed mb-8">
+                    {$m2t.guideDesc}
+                </p>
+                <p class="text-base text-white/40 italic">
+                    {$m2t.guideReassurance}
+                </p>
+            </div>
+        </section>
+
+        <!-- Section 4: The Pulse -->
+        <section class="py-32 px-6" id="how">
+            <div class="max-w-3xl mx-auto reveal-section" use:reveal>
+                <div class="text-center mb-16">
+                    <div class="w-12 h-12 rounded-full bg-teal-500/10 flex items-center justify-center mx-auto mb-8">
+                        <Heart size={24} class="text-teal-400/70" />
+                    </div>
+                    <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8">
+                        {$m2t.pulseTitle}
+                    </h2>
+                    <p class="text-lg text-white/50 leading-relaxed">
+                        {$m2t.pulseDesc}
+                    </p>
+                </div>
+
+                <div class="space-y-8 text-center">
+                    <p class="text-lg text-white/50 leading-relaxed">
+                        {$m2t.pulseHow}
+                    </p>
+                    <p class="text-xl text-teal-400/80 font-serif italic">
+                        {$m2t.pulseGift}
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 5: The Distinction -->
+        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent" id="security">
+            <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
+                <div class="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mx-auto mb-8">
+                    <Shield size={24} class="text-white/50" />
+                </div>
+                <h2 class="text-2xl md:text-3xl font-serif text-white/80 mb-6">
+                    {$m2t.distinctionTitle}
+                </h2>
+                <p class="text-base text-white/40 leading-relaxed mb-4">
+                    {$m2t.distinctionDesc}
+                </p>
+                <p class="text-base text-white/50 leading-relaxed mb-8">
+                    {$m2t.distinctionRole}
+                </p>
+                <p class="text-lg text-white/60 font-serif italic">
+                    {$m2t.distinctionTagline}
+                </p>
+            </div>
+        </section>
+
+        <!-- Section 6: The Gift -->
+        <section class="py-32 px-6" id="features">
+            <div class="max-w-4xl mx-auto reveal-section" use:reveal>
+                <h2 class="text-3xl md:text-4xl font-serif text-white/90 text-center mb-16">
+                    {$m2t.giftTitle}
+                </h2>
+
+                <div class="grid md:grid-cols-3 gap-8">
+                    <!-- Clarity -->
+                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftClarity}</h3>
+                        <p class="text-sm text-white/40">{$m2t.giftClarityDesc}</p>
+                    </div>
+
+                    <!-- Guidance -->
+                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftGuidance}</h3>
+                        <p class="text-sm text-white/40">{$m2t.giftGuidanceDesc}</p>
+                    </div>
+
+                    <!-- Voice -->
+                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
+                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftVoice}</h3>
+                        <p class="text-sm text-white/40">{$m2t.giftVoiceDesc}</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 7: The Invitation & Signup -->
+        <section class="py-32 px-6 min-h-[80vh] flex items-center">
+            <div class="max-w-2xl mx-auto w-full reveal-section" use:reveal>
+                {#if signupStep === 0}
+                    <!-- Name step -->
+                    <div class="text-center" in:fade={{ duration: 400 }}>
+                        <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-4">
+                            {$m2t.invitationTitle}
+                        </h2>
+                        <p class="text-lg text-white/50 mb-12">
+                            {$m2t.invitationDesc}
+                        </p>
+
+                        <div class="max-w-md mx-auto space-y-6">
+                            <p class="text-sm text-white/40">{$m2t.signupNamePrompt}</p>
+                            <input
+                                type="text"
+                                bind:value={name}
+                                placeholder={$m2t.signupNamePlaceholder}
+                                onkeydown={(e) => e.key === "Enter" && handleNameSubmit()}
+                                class="w-full bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-2xl font-serif text-center text-white/90 outline-none transition-colors placeholder:text-white/20"
+                            />
+
+                            {#if name.trim().length > 1}
+                                <button
+                                    onclick={handleNameSubmit}
+                                    class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
+                                    in:fade
+                                >
+                                    {$m2t.signupButton}
+                                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                                </button>
+                            {/if}
+                        </div>
+                    </div>
+                {:else if signupStep === 1}
+                    <!-- Email step -->
+                    <div class="text-center" in:fade={{ duration: 400 }}>
+                        <p class="text-sm text-white/40 mb-8">{$m2t.signupEmailPrompt}</p>
+                        <input
+                            type="email"
+                            bind:value={email}
+                            placeholder={$m2t.signupEmailPlaceholder}
+                            onkeydown={(e) => e.key === "Enter" && handleEmailSubmit()}
+                            class="w-full max-w-md mx-auto block bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-xl text-center text-white/90 outline-none transition-colors placeholder:text-white/20"
+                        />
+
+                        {#if email.includes("@") && email.includes(".")}
+                            <button
+                                onclick={handleEmailSubmit}
+                                class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/30 rounded-full text-amber-200 transition-all group"
+                                in:fade
+                            >
+                                {$m2t.signupButton}
+                                <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                            </button>
+                        {/if}
+
+                        <button
+                            onclick={() => signupStep = 0}
+                            class="mt-6 block mx-auto text-sm text-white/30 hover:text-white/50 transition-colors"
+                        >
+                            {$m2t.signupBack}
+                        </button>
+                    </div>
+                {:else}
+                    <!-- Welcome step -->
+                    <div class="text-center" in:scale={{ duration: 500, start: 0.95 }}>
+                        <div class="w-16 h-16 rounded-full bg-teal-500/10 border border-teal-500/30 flex items-center justify-center mx-auto mb-8">
+                            <Heart size={28} class="text-teal-400" />
+                        </div>
+                        <h2 class="text-3xl font-serif text-white/90 mb-2">
+                            {$m2t.signupWelcome} {name}.
+                        </h2>
+                        <p class="text-lg text-white/50 mb-8">
+                            {$m2t.signupNext}
+                        </p>
+                        <a
+                            href="/start?email={encodeURIComponent(email)}"
+                            class="inline-flex items-center gap-3 px-8 py-4 bg-teal-500/20 hover:bg-teal-500/30 border border-teal-500/30 rounded-full text-teal-200 transition-all group"
+                        >
+                            {$m2t.signupEnter}
+                            <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                        </a>
+                    </div>
+                {/if}
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="py-12 px-6 border-t border-white/5">
+        <div class="max-w-4xl mx-auto text-center space-y-4">
+            <p class="text-xs text-white/30">
+                {$m2t.footerDisclaimer}
+            </p>
+            <p class="text-sm text-white/20 font-serif italic">
+                {$m2t.footerTagline}
+            </p>
+        </div>
+    </footer>
+</div>
+
+<style>
+    /* Reveal animation */
+    .reveal-section {
+        opacity: 0;
+        transform: translateY(30px);
+        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+    }
+
+    .reveal-section.revealed {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    /* Smooth scroll */
+    :global(html) {
+        scroll-behavior: smooth;
+    }
+</style>

--- a/frontend/src/routes/marketing2/+page.svelte
+++ b/frontend/src/routes/marketing2/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { fade, fly, scale } from "svelte/transition";
-    import { cubicOut } from "svelte/easing";
+    import { fade, fly, scale, slide } from "svelte/transition";
+    import { cubicOut, backOut, elasticOut } from "svelte/easing";
+    import { spring, tweened } from "svelte/motion";
     import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
     import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
     import {
@@ -23,24 +24,63 @@
     } from "$lib/stores/keyringStore";
     import { get } from "svelte/store";
 
+    // Core state
     let scrollY = $state(0);
     let innerHeight = $state(0);
+    let innerWidth = $state(0);
     let introVisible = $state(false);
     let langMenuOpen = $state(false);
     let mobileMenuOpen = $state(false);
+    let mouseX = $state(0);
+    let mouseY = $state(0);
+    let prefersReducedMotion = $state(false);
 
     // Signup flow state
     let name = $state("");
     let email = $state("");
-    let signupStep = $state(0); // 0: name, 1: email, 2: welcome
+    let signupStep = $state(0);
 
-    // Intersection observer for reveal animations
-    function reveal(node: HTMLElement) {
+    // Easter egg state
+    let easterEggActive = $state(false);
+    let konamiIndex = $state(0);
+    const konamiCode = ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown", "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a"];
+
+    // Touch gesture state
+    let touchStartY = $state(0);
+    let touchStartX = $state(0);
+
+    // Spring physics for smooth animations
+    const cursorGlow = spring({ x: 0, y: 0 }, { stiffness: 0.1, damping: 0.4 });
+    const scrollProgress = tweened(0, { duration: 150 });
+
+    // Floating elements positions (parallax)
+    const floatOffset1 = $derived(scrollY * 0.05);
+    const floatOffset2 = $derived(scrollY * 0.08);
+    const floatOffset3 = $derived(scrollY * 0.03);
+
+    // Section visibility tracking for scroll-linked animations
+    let heroRef: HTMLElement | null = $state(null);
+    let kitchenRef: HTMLElement | null = $state(null);
+    let weightRef: HTMLElement | null = $state(null);
+    let guideRef: HTMLElement | null = $state(null);
+    let pulseRef: HTMLElement | null = $state(null);
+    let currentSection = $state(0);
+
+    // Intersection observer for staggered reveals
+    function reveal(node: HTMLElement, options: { delay?: number; stagger?: boolean } = {}) {
+        if (prefersReducedMotion) {
+            node.classList.add("revealed");
+            return { destroy: () => {} };
+        }
+
         const observer = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {
                     if (entry.isIntersecting) {
-                        node.classList.add("revealed");
+                        const delay = options.delay || 0;
+                        setTimeout(() => {
+                            node.classList.add("revealed");
+                        }, delay);
                     }
                 });
             },
@@ -50,10 +90,150 @@
         return { destroy: () => observer.disconnect() };
     }
 
+    // 3D card tilt effect
+    function tilt3D(node: HTMLElement) {
+        if (prefersReducedMotion) return { destroy: () => {} };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            const rect = node.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            const centerX = rect.width / 2;
+            const centerY = rect.height / 2;
+            const rotateX = (y - centerY) / 20;
+            const rotateY = (centerX - x) / 20;
+
+            node.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
+            node.style.boxShadow = `${rotateY}px ${rotateX}px 30px rgba(0,0,0,0.3)`;
+        };
+
+        const handleMouseLeave = () => {
+            node.style.transform = "perspective(1000px) rotateX(0) rotateY(0) scale(1)";
+            node.style.boxShadow = "0 0 0 rgba(0,0,0,0)";
+        };
+
+        node.addEventListener("mousemove", handleMouseMove);
+        node.addEventListener("mouseleave", handleMouseLeave);
+
+        return {
+            destroy() {
+                node.removeEventListener("mousemove", handleMouseMove);
+                node.removeEventListener("mouseleave", handleMouseLeave);
+            }
+        };
+    }
+
+    // Text reveal animation - word by word
+    function textReveal(node: HTMLElement, options: { delay?: number } = {}) {
+        if (prefersReducedMotion) return { destroy: () => {} };
+
+        const text = node.textContent || "";
+        const words = text.split(" ");
+        node.innerHTML = "";
+        node.style.opacity = "1";
+
+        words.forEach((word, i) => {
+            const span = document.createElement("span");
+            span.textContent = word + " ";
+            span.style.opacity = "0";
+            span.style.transform = "translateY(20px)";
+            span.style.display = "inline-block";
+            span.style.transition = `opacity 0.5s ease ${(options.delay || 0) + i * 0.05}s, transform 0.5s ease ${(options.delay || 0) + i * 0.05}s`;
+            node.appendChild(span);
+        });
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        const spans = node.querySelectorAll("span");
+                        spans.forEach((span) => {
+                            (span as HTMLElement).style.opacity = "1";
+                            (span as HTMLElement).style.transform = "translateY(0)";
+                        });
+                    }
+                });
+            },
+            { threshold: 0.5 }
+        );
+        observer.observe(node);
+        return { destroy: () => observer.disconnect() };
+    }
+
     onMount(() => {
-        // Scroll to top on mount
         window.scrollTo(0, 0);
         setTimeout(() => (introVisible = true), 300);
+
+        // Check for reduced motion preference
+        prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+        // Update scroll progress
+        const updateScroll = () => {
+            const docHeight = document.documentElement.scrollHeight - innerHeight;
+            scrollProgress.set(scrollY / docHeight);
+        };
+
+        // Track mouse for cursor glow
+        const handleMouseMove = (e: MouseEvent) => {
+            mouseX = e.clientX;
+            mouseY = e.clientY;
+            cursorGlow.set({ x: e.clientX, y: e.clientY });
+        };
+
+        // Easter egg: Konami code
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === konamiCode[konamiIndex]) {
+                konamiIndex++;
+                if (konamiIndex === konamiCode.length) {
+                    easterEggActive = true;
+                    konamiIndex = 0;
+                    // Reset after animation
+                    setTimeout(() => {
+                        easterEggActive = false;
+                    }, 5000);
+                }
+            } else {
+                konamiIndex = 0;
+            }
+        };
+
+        // Touch gesture support for swipe navigation
+        const handleTouchStart = (e: TouchEvent) => {
+            touchStartY = e.touches[0].clientY;
+            touchStartX = e.touches[0].clientX;
+        };
+
+        const handleTouchEnd = (e: TouchEvent) => {
+            const touchEndX = e.changedTouches[0].clientX;
+            const touchEndY = e.changedTouches[0].clientY;
+            const diffX = touchStartX - touchEndX;
+            const diffY = touchStartY - touchEndY;
+
+            // Horizontal swipe (navigate between pages)
+            if (Math.abs(diffX) > Math.abs(diffY) && Math.abs(diffX) > 100) {
+                if (diffX > 0) {
+                    // Swipe left - go to features
+                    window.location.href = "/marketing2/features";
+                } else {
+                    // Swipe right - go to how
+                    window.location.href = "/marketing2/how";
+                }
+            }
+        };
+
+        window.addEventListener("scroll", updateScroll);
+        window.addEventListener("mousemove", handleMouseMove);
+        window.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("touchstart", handleTouchStart, { passive: true });
+        document.addEventListener("touchend", handleTouchEnd, { passive: true });
+
+        return () => {
+            window.removeEventListener("scroll", updateScroll);
+            window.removeEventListener("mousemove", handleMouseMove);
+            window.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener("touchstart", handleTouchStart);
+            document.removeEventListener("touchend", handleTouchEnd);
+        };
     });
 
     function handleNameSubmit() {
@@ -82,8 +262,9 @@
         langMenuOpen = false;
     }
 
-    // Computed scroll progress for hero
+    // Computed values
     const heroOpacity = $derived(Math.max(0, 1 - scrollY / (innerHeight * 0.5)));
+    const heroScale = $derived(1 - scrollY / (innerHeight * 3));
 </script>
 
 <svelte:head>
@@ -97,13 +278,95 @@
     <meta name="twitter:description" content={$m2t.metaDescription} />
 </svelte:head>
 
-<svelte:window bind:scrollY bind:innerHeight />
+<svelte:window bind:scrollY bind:innerHeight bind:innerWidth />
 
-<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
-    <!-- Subtle Background -->
-    <div class="fixed inset-0 z-0 pointer-events-none">
-        <!-- Gradient overlay -->
-        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+<div class="min-h-screen bg-[#0a0a0b] text-white overflow-x-hidden" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Easter Egg Animation (Konami Code: ↑↑↓↓←→←→BA) -->
+    {#if easterEggActive}
+        <div class="fixed inset-0 z-[200] pointer-events-none overflow-hidden easter-egg-container">
+            {#each Array(30) as _, i}
+                <div
+                    class="absolute text-4xl easter-heart"
+                    style="
+                        left: {Math.random() * 100}%;
+                        animation-delay: {Math.random() * 2}s;
+                    "
+                >
+                    💛
+                </div>
+            {/each}
+            <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center easter-message">
+                <p class="text-2xl font-serif text-amber-400">Thank you for caring.</p>
+                <p class="text-sm text-white/50 mt-2">Your loved ones are lucky to have you.</p>
+            </div>
+        </div>
+    {/if}
+
+    <!-- Cursor Glow Effect (Desktop only) -->
+    {#if innerWidth > 768 && !prefersReducedMotion}
+        <div
+            class="pointer-events-none fixed z-50 w-96 h-96 rounded-full opacity-20 blur-3xl"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.15) 0%, transparent 70%);
+                left: {$cursorGlow.x - 192}px;
+                top: {$cursorGlow.y - 192}px;
+                transition: opacity 0.3s;
+            "
+        ></div>
+    {/if}
+
+    <!-- Scroll Progress Indicator -->
+    <div
+        class="fixed top-0 left-0 h-[2px] bg-gradient-to-r from-amber-500 via-teal-500 to-rose-500 z-[100] origin-left"
+        style="transform: scaleX({$scrollProgress})"
+    ></div>
+
+    <!-- Animated Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none overflow-hidden">
+        <!-- Animated gradient orbs -->
+        <div
+            class="absolute w-[800px] h-[800px] rounded-full opacity-30 blur-[120px] animate-float-slow"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.1) 0%, transparent 70%);
+                top: -20%;
+                left: -10%;
+                transform: translateY({floatOffset1}px);
+            "
+        ></div>
+        <div
+            class="absolute w-[600px] h-[600px] rounded-full opacity-20 blur-[100px] animate-float-medium"
+            style="
+                background: radial-gradient(circle, rgba(20, 184, 166, 0.1) 0%, transparent 70%);
+                top: 40%;
+                right: -15%;
+                transform: translateY({-floatOffset2}px);
+            "
+        ></div>
+        <div
+            class="absolute w-[500px] h-[500px] rounded-full opacity-20 blur-[80px] animate-float-fast"
+            style="
+                background: radial-gradient(circle, rgba(244, 63, 94, 0.08) 0%, transparent 70%);
+                bottom: 10%;
+                left: 20%;
+                transform: translateY({floatOffset3}px);
+            "
+        ></div>
+
+        <!-- Floating particles -->
+        {#if !prefersReducedMotion}
+            {#each Array(12) as _, i}
+                <div
+                    class="absolute w-1 h-1 rounded-full bg-white/10 animate-float-particle"
+                    style="
+                        left: {10 + (i * 7)}%;
+                        top: {20 + (i * 5) % 60}%;
+                        animation-delay: {i * 0.5}s;
+                        animation-duration: {8 + (i % 4)}s;
+                    "
+                ></div>
+            {/each}
+        {/if}
+
         <!-- Subtle grain -->
         <div
             class="absolute inset-0 opacity-[0.03]"
@@ -112,18 +375,25 @@
     </div>
 
     <!-- Header -->
-    <header class="fixed top-0 left-0 right-0 z-50 transition-all duration-500" class:bg-black/80={scrollY > 100} class:backdrop-blur-md={scrollY > 100}>
+    <header
+        class="fixed top-0 left-0 right-0 z-50 transition-all duration-500"
+        class:bg-black/80={scrollY > 100}
+        class:backdrop-blur-md={scrollY > 100}
+    >
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-            <!-- Logo -->
-            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+            <!-- Logo with hover animation -->
+            <a
+                href="/marketing2"
+                class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-all duration-300 hover:tracking-wider"
+            >
                 Continuum
             </a>
 
-            <!-- Nav -->
+            <!-- Nav with hover underlines -->
             <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
-                <a href="/marketing2/how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
-                <a href="/marketing2/features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
-                <a href="#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2/how" class="nav-link">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="nav-link">{$m2t.navFeatures}</a>
+                <a href="#security" class="nav-link">{$m2t.navSecurity}</a>
             </nav>
 
             <!-- Right side -->
@@ -134,35 +404,38 @@
                     class="md:hidden text-white/60 hover:text-white transition-colors p-2"
                     aria-label="Toggle menu"
                 >
-                    {#if mobileMenuOpen}
-                        <X size={24} />
-                    {:else}
-                        <Menu size={24} />
-                    {/if}
+                    <div class="relative w-6 h-6">
+                        {#if mobileMenuOpen}
+                            <X size={24} class="absolute inset-0 animate-spin-in" />
+                        {:else}
+                            <Menu size={24} class="absolute inset-0" />
+                        {/if}
+                    </div>
                 </button>
 
                 <!-- Language selector -->
                 <div class="relative">
                     <button
                         onclick={() => langMenuOpen = !langMenuOpen}
-                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm group"
                     >
-                        <Globe size={16} />
+                        <Globe size={16} class="group-hover:animate-spin-slow" />
                         <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
-                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                        <ChevronDown size={14} class="transition-transform duration-300" class:rotate-180={langMenuOpen} />
                     </button>
 
                     {#if langMenuOpen}
                         <div
                             class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
-                            transition:fade={{ duration: 150 }}
+                            transition:fly={{ y: -10, duration: 200 }}
                         >
-                            {#each availableLanguages as lang}
+                            {#each availableLanguages as lang, i}
                                 <button
                                     onclick={() => setLanguage(lang.code as Marketing2Language)}
-                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-all duration-200"
                                     class:text-amber-400={$m2Language === lang.code}
                                     class:text-white/70={$m2Language !== lang.code}
+                                    style="animation: slideIn 0.2s ease {i * 0.05}s both"
                                 >
                                     {lang.native}
                                 </button>
@@ -171,44 +444,37 @@
                     {/if}
                 </div>
 
-                <!-- Login -->
+                <!-- Login button with glow -->
                 <a
                     href="/login"
-                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all duration-300 hover:shadow-[0_0_20px_rgba(251,191,36,0.2)]"
                 >
                     {$m2t.navLogin}
                 </a>
             </div>
         </div>
 
-        <!-- Mobile menu -->
+        <!-- Mobile menu with slide animation -->
         {#if mobileMenuOpen}
             <div
-                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
-                transition:fade={{ duration: 150 }}
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md overflow-hidden"
+                transition:slide={{ duration: 300 }}
             >
-                <nav class="flex flex-col px-6 py-4 space-y-4">
-                    <a
-                        href="/marketing2/how"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navHow}
-                    </a>
-                    <a
-                        href="/marketing2/features"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navFeatures}
-                    </a>
-                    <a
-                        href="#security"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navSecurity}
-                    </a>
+                <nav class="flex flex-col px-6 py-4 space-y-2">
+                    {#each [
+                        { href: "/marketing2/how", label: $m2t.navHow },
+                        { href: "/marketing2/features", label: $m2t.navFeatures },
+                        { href: "#security", label: $m2t.navSecurity }
+                    ] as item, i}
+                        <a
+                            href={item.href}
+                            class="text-white/60 hover:text-white transition-all duration-200 py-3 border-b border-white/5 last:border-0"
+                            onclick={() => mobileMenuOpen = false}
+                            style="animation: slideIn 0.3s ease {i * 0.1}s both"
+                        >
+                            {item.label}
+                        </a>
+                    {/each}
                 </nav>
             </div>
         {/if}
@@ -216,101 +482,140 @@
 
     <main class="relative z-10">
         <!-- Section 1: The Shoebox (Hero) -->
-        <section class="min-h-screen flex items-center justify-center px-6 relative">
+        <section class="min-h-screen flex items-center justify-center px-6 relative" bind:this={heroRef}>
             <div
                 class="text-center max-w-3xl mx-auto"
-                style="opacity: {heroOpacity}; transform: translateY({scrollY * 0.1}px);"
+                style="
+                    opacity: {heroOpacity};
+                    transform: translateY({scrollY * 0.15}px) scale({Math.max(0.9, heroScale)});
+                "
             >
                 {#if introVisible}
-                    <div class="space-y-4 mb-8" in:fade={{ duration: 800, delay: 200 }}>
-                        <h1 class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/90 leading-tight">
+                    <div class="space-y-4 mb-8">
+                        <h1
+                            class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/90 leading-tight"
+                            in:fly={{ y: 30, duration: 800, delay: 200, easing: backOut }}
+                        >
                             {$m2t.heroLine1}
                         </h1>
-                        <h1 class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/60 leading-tight">
+                        <h1
+                            class="text-4xl md:text-6xl lg:text-7xl font-serif font-light text-white/60 leading-tight"
+                            in:fly={{ y: 30, duration: 800, delay: 400, easing: backOut }}
+                        >
                             {$m2t.heroLine2}
                         </h1>
                     </div>
 
                     <div in:fade={{ duration: 800, delay: 600 }}>
-                        <p class="text-2xl md:text-3xl font-serif text-amber-400/90 mb-8">
+                        <p
+                            class="text-2xl md:text-3xl font-serif text-amber-400/90 mb-8"
+                            in:fly={{ y: 20, duration: 800, delay: 800, easing: backOut }}
+                        >
                             {$m2t.heroLine3}
                         </p>
-                        <p class="text-lg text-white/50 max-w-xl mx-auto mb-10">
+                        <p
+                            class="text-lg text-white/50 max-w-xl mx-auto mb-10"
+                            in:fly={{ y: 20, duration: 800, delay: 1000 }}
+                        >
                             {$m2t.heroDesc}
                         </p>
                         <a
                             href="/marketing2/features"
-                            class="inline-flex items-center gap-2 text-sm text-white/40 hover:text-white/60 transition-colors"
+                            class="inline-flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-all duration-300 group"
+                            in:fade={{ duration: 500, delay: 1200 }}
                         >
                             {$m2t.ctaExplore}
-                            <ArrowRight size={16} />
+                            <ArrowRight size={16} class="group-hover:translate-x-1 transition-transform duration-300" />
                         </a>
                     </div>
                 {/if}
             </div>
 
-            <!-- Scroll indicator -->
-            <div class="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3 text-white/30" style="opacity: {heroOpacity};">
-                <div class="w-px h-12 bg-gradient-to-b from-white/20 to-transparent"></div>
+            <!-- Animated scroll indicator -->
+            <div
+                class="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3"
+                style="opacity: {heroOpacity};"
+            >
+                <div class="scroll-indicator">
+                    <div class="scroll-dot"></div>
+                </div>
             </div>
         </section>
 
         <!-- Section 1.5: The Kitchen Story -->
-        <section class="py-24 px-6 bg-gradient-to-b from-transparent via-rose-950/5 to-transparent">
+        <section class="py-24 px-6 bg-gradient-to-b from-transparent via-rose-950/5 to-transparent" bind:this={kitchenRef}>
             <div class="max-w-2xl mx-auto reveal-section" use:reveal>
-                <h2 class="text-2xl md:text-3xl font-serif text-white/80 text-center mb-10">
+                <h2
+                    class="text-2xl md:text-3xl font-serif text-white/80 text-center mb-10"
+                    use:textReveal
+                >
                     {$m2t.kitchenTitle}
                 </h2>
-                <p class="text-lg text-white/40 leading-relaxed mb-10 italic">
+                <p
+                    class="text-lg text-white/40 leading-relaxed mb-10 italic reveal-section"
+                    use:reveal={{ delay: 200 }}
+                >
                     {$m2t.kitchenDesc}
                 </p>
-                <p class="text-xl text-rose-400/70 font-serif text-center">
+                <p
+                    class="text-xl text-rose-400/70 font-serif text-center reveal-section"
+                    use:reveal={{ delay: 400 }}
+                >
                     {$m2t.kitchenPunchline}
                 </p>
             </div>
         </section>
 
         <!-- Section 2: The Weight -->
-        <section class="py-32 px-6">
+        <section class="py-32 px-6" bind:this={weightRef}>
             <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
-                <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8 leading-relaxed">
+                <h2
+                    class="text-3xl md:text-4xl font-serif text-white/90 mb-8 leading-relaxed"
+                    use:textReveal
+                >
                     {$m2t.weightTitle}
                 </h2>
-                <p class="text-lg text-white/50 leading-relaxed mb-12">
+                <p class="text-lg text-white/50 leading-relaxed mb-12 reveal-section" use:reveal={{ delay: 200 }}>
                     {$m2t.weightDesc}
                 </p>
-                <p class="text-xl text-amber-400/80 font-serif italic">
+                <p class="text-xl text-amber-400/80 font-serif italic reveal-section" use:reveal={{ delay: 400 }}>
                     {$m2t.weightBridge}
                 </p>
             </div>
         </section>
 
         <!-- Section 3: The Guide -->
-        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-amber-950/5 to-transparent">
+        <section class="py-32 px-6 bg-gradient-to-b from-transparent via-amber-950/5 to-transparent" bind:this={guideRef}>
             <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
-                <div class="w-12 h-12 rounded-full bg-amber-500/10 flex items-center justify-center mx-auto mb-8">
-                    <Compass size={24} class="text-amber-400/70" />
+                <div class="icon-container w-12 h-12 rounded-full bg-amber-500/10 flex items-center justify-center mx-auto mb-8">
+                    <Compass size={24} class="text-amber-400/70 icon-spin" />
                 </div>
-                <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8">
+                <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8" use:textReveal>
                     {$m2t.guideTitle}
                 </h2>
-                <p class="text-lg text-white/50 leading-relaxed mb-8">
+                <p class="text-lg text-white/50 leading-relaxed mb-8 reveal-section" use:reveal={{ delay: 200 }}>
                     {$m2t.guideDesc}
                 </p>
-                <p class="text-base text-white/40 italic">
+                <p class="text-base text-white/40 italic reveal-section" use:reveal={{ delay: 400 }}>
                     {$m2t.guideReassurance}
                 </p>
             </div>
         </section>
 
         <!-- Section 4: The Pulse -->
-        <section class="py-32 px-6" id="how">
+        <section class="py-32 px-6" id="how" bind:this={pulseRef}>
             <div class="max-w-3xl mx-auto reveal-section" use:reveal>
                 <div class="text-center mb-16">
-                    <div class="w-12 h-12 rounded-full bg-teal-500/10 flex items-center justify-center mx-auto mb-8">
-                        <Heart size={24} class="text-teal-400/70" />
+                    <!-- Animated Pulse Visualization -->
+                    <div class="relative w-24 h-24 mx-auto mb-8">
+                        <div class="pulse-ring pulse-ring-1"></div>
+                        <div class="pulse-ring pulse-ring-2"></div>
+                        <div class="pulse-ring pulse-ring-3"></div>
+                        <div class="w-12 h-12 rounded-full bg-teal-500/20 flex items-center justify-center absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+                            <Heart size={24} class="text-teal-400 heart-beat" />
+                        </div>
                     </div>
-                    <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8">
+                    <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-8" use:textReveal>
                         {$m2t.pulseTitle}
                     </h2>
                     <p class="text-lg text-white/50 leading-relaxed">
@@ -319,13 +624,13 @@
                 </div>
 
                 <div class="space-y-8 text-center">
-                    <p class="text-lg text-white/50 leading-relaxed">
+                    <p class="text-lg text-white/50 leading-relaxed reveal-section" use:reveal={{ delay: 200 }}>
                         {$m2t.pulseHow}
                     </p>
-                    <p class="text-base text-white/40 leading-relaxed">
+                    <p class="text-base text-white/40 leading-relaxed reveal-section" use:reveal={{ delay: 400 }}>
                         {$m2t.pulseTiers}
                     </p>
-                    <p class="text-xl text-teal-400/80 font-serif italic">
+                    <p class="text-xl text-teal-400/80 font-serif italic reveal-section" use:reveal={{ delay: 600 }}>
                         {$m2t.pulseGift}
                     </p>
                 </div>
@@ -335,8 +640,8 @@
         <!-- Section 5: The Distinction -->
         <section class="py-32 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent">
             <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
-                <div class="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mx-auto mb-8">
-                    <Shield size={24} class="text-white/50" />
+                <div class="icon-container w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mx-auto mb-8">
+                    <Shield size={24} class="text-white/50 icon-pulse" />
                 </div>
                 <h2 class="text-2xl md:text-3xl font-serif text-white/80 mb-6">
                     {$m2t.distinctionTitle}
@@ -357,8 +662,8 @@
         <section class="py-32 px-6" id="security">
             <div class="max-w-4xl mx-auto reveal-section" use:reveal>
                 <div class="text-center mb-16">
-                    <div class="w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center mx-auto mb-8">
-                        <Lock size={24} class="text-emerald-400/70" />
+                    <div class="icon-container w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center mx-auto mb-8">
+                        <Lock size={24} class="text-emerald-400/70 icon-shimmer" />
                     </div>
                     <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-6">
                         {$m2t.securityTitle}
@@ -369,18 +674,20 @@
                 </div>
 
                 <div class="grid md:grid-cols-3 gap-8">
-                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityEncryption}</h3>
-                        <p class="text-sm text-white/40">{$m2t.securityEncryptionDesc}</p>
-                    </div>
-                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityPrivacy}</h3>
-                        <p class="text-sm text-white/40">{$m2t.securityPrivacyDesc}</p>
-                    </div>
-                    <div class="text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{$m2t.securityControl}</h3>
-                        <p class="text-sm text-white/40">{$m2t.securityControlDesc}</p>
-                    </div>
+                    {#each [
+                        { title: $m2t.securityEncryption, desc: $m2t.securityEncryptionDesc },
+                        { title: $m2t.securityPrivacy, desc: $m2t.securityPrivacyDesc },
+                        { title: $m2t.securityControl, desc: $m2t.securityControlDesc }
+                    ] as card, i}
+                        <div
+                            class="card-3d text-center p-6 rounded-2xl bg-white/[0.02] border border-white/5 reveal-section transition-all duration-500"
+                            use:reveal={{ delay: i * 150 }}
+                            use:tilt3D
+                        >
+                            <h3 class="text-lg font-serif text-emerald-400/90 mb-3">{card.title}</h3>
+                            <p class="text-sm text-white/40">{card.desc}</p>
+                        </div>
+                    {/each}
                 </div>
             </div>
         </section>
@@ -393,23 +700,37 @@
                 </h2>
 
                 <div class="grid md:grid-cols-3 gap-8">
-                    <!-- Clarity -->
-                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftClarity}</h3>
-                        <p class="text-sm text-white/40">{$m2t.giftClarityDesc}</p>
-                    </div>
+                    {#each [
+                        { title: $m2t.giftClarity, desc: $m2t.giftClarityDesc, color: "amber" },
+                        { title: $m2t.giftGuidance, desc: $m2t.giftGuidanceDesc, color: "amber" },
+                        { title: $m2t.giftVoice, desc: $m2t.giftVoiceDesc, color: "amber" }
+                    ] as card, i}
+                        <div
+                            class="card-3d text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5 reveal-section transition-all duration-500"
+                            use:reveal={{ delay: i * 150 }}
+                            use:tilt3D
+                        >
+                            <h3 class="text-xl font-serif text-amber-400/90 mb-3">{card.title}</h3>
+                            <p class="text-sm text-white/40">{card.desc}</p>
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </section>
 
-                    <!-- Guidance -->
-                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftGuidance}</h3>
-                        <p class="text-sm text-white/40">{$m2t.giftGuidanceDesc}</p>
+        <!-- Testimonial Section -->
+        <section class="py-24 px-6 bg-gradient-to-b from-transparent via-white/[0.01] to-transparent">
+            <div class="max-w-3xl mx-auto reveal-section" use:reveal>
+                <div class="text-center">
+                    <div class="flex justify-center mb-6">
+                        {#each Array(5) as _, i}
+                            <span class="text-amber-400/60 text-sm" style="animation: starPop 0.3s ease {i * 0.1}s both">★</span>
+                        {/each}
                     </div>
-
-                    <!-- Voice -->
-                    <div class="text-center p-8 rounded-2xl bg-white/[0.02] border border-white/5">
-                        <h3 class="text-xl font-serif text-amber-400/90 mb-3">{$m2t.giftVoice}</h3>
-                        <p class="text-sm text-white/40">{$m2t.giftVoiceDesc}</p>
-                    </div>
+                    <blockquote class="text-xl md:text-2xl font-serif text-white/70 italic mb-8 leading-relaxed">
+                        "I spent months putting off this conversation with my family. Continuum let me say everything I needed to say, in my own time, in my own words."
+                    </blockquote>
+                    <p class="text-sm text-white/40">— A Continuum user</p>
                 </div>
             </div>
         </section>
@@ -418,7 +739,6 @@
         <section class="py-32 px-6 min-h-[80vh] flex items-center">
             <div class="max-w-2xl mx-auto w-full reveal-section" use:reveal>
                 {#if signupStep === 0}
-                    <!-- Name step -->
                     <div class="text-center" in:fade={{ duration: 400 }}>
                         <h2 class="text-3xl md:text-4xl font-serif text-white/90 mb-4">
                             {$m2t.invitationTitle}
@@ -434,14 +754,14 @@
                                 bind:value={name}
                                 placeholder={$m2t.signupNamePlaceholder}
                                 onkeydown={(e) => e.key === "Enter" && handleNameSubmit()}
-                                class="w-full bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-2xl font-serif text-center text-white/90 outline-none transition-colors placeholder:text-white/20"
+                                class="w-full bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-2xl font-serif text-center text-white/90 outline-none transition-all duration-300 placeholder:text-white/20 focus:shadow-[0_4px_20px_-4px_rgba(251,191,36,0.3)]"
                             />
 
                             {#if name.trim().length > 1}
                                 <button
                                     onclick={handleNameSubmit}
-                                    class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
-                                    in:fade
+                                    class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all duration-300 group hover:shadow-[0_0_30px_rgba(251,191,36,0.2)]"
+                                    in:scale={{ duration: 300, start: 0.9, easing: backOut }}
                                 >
                                     {$m2t.signupButton}
                                     <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
@@ -450,22 +770,21 @@
                         </div>
                     </div>
                 {:else if signupStep === 1}
-                    <!-- Email step -->
-                    <div class="text-center" in:fade={{ duration: 400 }}>
+                    <div class="text-center" in:fly={{ x: 50, duration: 400 }}>
                         <p class="text-sm text-white/40 mb-8">{$m2t.signupEmailPrompt}</p>
                         <input
                             type="email"
                             bind:value={email}
                             placeholder={$m2t.signupEmailPlaceholder}
                             onkeydown={(e) => e.key === "Enter" && handleEmailSubmit()}
-                            class="w-full max-w-md mx-auto block bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-xl text-center text-white/90 outline-none transition-colors placeholder:text-white/20"
+                            class="w-full max-w-md mx-auto block bg-transparent border-b border-white/20 focus:border-amber-500/50 py-4 text-xl text-center text-white/90 outline-none transition-all duration-300 placeholder:text-white/20 focus:shadow-[0_4px_20px_-4px_rgba(251,191,36,0.3)]"
                         />
 
                         {#if email.includes("@") && email.includes(".")}
                             <button
                                 onclick={handleEmailSubmit}
-                                class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/30 rounded-full text-amber-200 transition-all group"
-                                in:fade
+                                class="mt-8 inline-flex items-center gap-3 px-8 py-4 bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/30 rounded-full text-amber-200 transition-all duration-300 group hover:shadow-[0_0_30px_rgba(251,191,36,0.3)]"
+                                in:scale={{ duration: 300, start: 0.9, easing: backOut }}
                             >
                                 {$m2t.signupButton}
                                 <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
@@ -480,10 +799,12 @@
                         </button>
                     </div>
                 {:else}
-                    <!-- Welcome step -->
-                    <div class="text-center" in:scale={{ duration: 500, start: 0.95 }}>
-                        <div class="w-16 h-16 rounded-full bg-teal-500/10 border border-teal-500/30 flex items-center justify-center mx-auto mb-8">
-                            <Heart size={28} class="text-teal-400" />
+                    <div class="text-center" in:scale={{ duration: 500, start: 0.9, easing: elasticOut }}>
+                        <div class="relative w-20 h-20 mx-auto mb-8">
+                            <div class="success-ring"></div>
+                            <div class="w-16 h-16 rounded-full bg-teal-500/10 border border-teal-500/30 flex items-center justify-center absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+                                <Heart size={28} class="text-teal-400" />
+                            </div>
                         </div>
                         <h2 class="text-3xl font-serif text-white/90 mb-2">
                             {$m2t.signupWelcome} {name}.
@@ -493,7 +814,7 @@
                         </p>
                         <a
                             href="/start?email={encodeURIComponent(email)}"
-                            class="inline-flex items-center gap-3 px-8 py-4 bg-teal-500/20 hover:bg-teal-500/30 border border-teal-500/30 rounded-full text-teal-200 transition-all group"
+                            class="inline-flex items-center gap-3 px-8 py-4 bg-teal-500/20 hover:bg-teal-500/30 border border-teal-500/30 rounded-full text-teal-200 transition-all duration-300 group hover:shadow-[0_0_30px_rgba(20,184,166,0.3)]"
                         >
                             {$m2t.signupEnter}
                             <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
@@ -508,9 +829,9 @@
     <footer class="py-12 px-6 border-t border-white/5">
         <div class="max-w-4xl mx-auto">
             <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
-                <a href="/marketing2/how" class="hover:text-white/60 transition-colors">{$m2t.navHow}</a>
-                <a href="/marketing2/features" class="hover:text-white/60 transition-colors">{$m2t.navFeatures}</a>
-                <a href="#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2/how" class="hover:text-white/60 transition-colors duration-300">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="hover:text-white/60 transition-colors duration-300">{$m2t.navFeatures}</a>
+                <a href="#security" class="hover:text-white/60 transition-colors duration-300">{$m2t.navSecurity}</a>
             </nav>
             <div class="text-center space-y-4">
                 <p class="text-xs text-white/30">
@@ -525,11 +846,11 @@
 </div>
 
 <style>
-    /* Reveal animation */
+    /* Reveal animations */
     .reveal-section {
         opacity: 0;
         transform: translateY(30px);
-        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+        transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
     }
 
     .reveal-section.revealed {
@@ -537,8 +858,305 @@
         transform: translateY(0);
     }
 
+    /* 3D Card transitions */
+    .card-3d {
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        transform-style: preserve-3d;
+    }
+
+    /* Nav link hover effect */
+    .nav-link {
+        position: relative;
+        padding-bottom: 4px;
+    }
+
+    .nav-link::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 0;
+        height: 1px;
+        background: linear-gradient(90deg, rgba(251, 191, 36, 0.5), rgba(20, 184, 166, 0.5));
+        transition: width 0.3s ease;
+    }
+
+    .nav-link:hover::after {
+        width: 100%;
+    }
+
+    .nav-link:hover {
+        color: white;
+    }
+
+    /* Floating animations */
+    @keyframes float-slow {
+        0%, 100% { transform: translateY(0) rotate(0deg); }
+        50% { transform: translateY(-30px) rotate(3deg); }
+    }
+
+    @keyframes float-medium {
+        0%, 100% { transform: translateY(0) rotate(0deg); }
+        50% { transform: translateY(-20px) rotate(-2deg); }
+    }
+
+    @keyframes float-fast {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-15px); }
+    }
+
+    @keyframes float-particle {
+        0%, 100% { transform: translateY(0) translateX(0); opacity: 0.1; }
+        25% { transform: translateY(-30px) translateX(10px); opacity: 0.3; }
+        50% { transform: translateY(-50px) translateX(-5px); opacity: 0.2; }
+        75% { transform: translateY(-30px) translateX(5px); opacity: 0.3; }
+    }
+
+    .animate-float-slow { animation: float-slow 20s ease-in-out infinite; }
+    .animate-float-medium { animation: float-medium 15s ease-in-out infinite; }
+    .animate-float-fast { animation: float-fast 10s ease-in-out infinite; }
+    .animate-float-particle { animation: float-particle 8s ease-in-out infinite; }
+
+    /* Scroll indicator */
+    .scroll-indicator {
+        width: 24px;
+        height: 40px;
+        border: 2px solid rgba(255, 255, 255, 0.2);
+        border-radius: 12px;
+        position: relative;
+    }
+
+    .scroll-dot {
+        width: 4px;
+        height: 8px;
+        background: rgba(255, 255, 255, 0.4);
+        border-radius: 2px;
+        position: absolute;
+        left: 50%;
+        top: 8px;
+        transform: translateX(-50%);
+        animation: scrollDot 2s ease-in-out infinite;
+    }
+
+    @keyframes scrollDot {
+        0%, 100% { top: 8px; opacity: 1; }
+        50% { top: 24px; opacity: 0.3; }
+    }
+
+    /* Pulse visualization */
+    .pulse-ring {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+        border: 1px solid rgba(20, 184, 166, 0.3);
+        animation: pulseRing 3s ease-out infinite;
+    }
+
+    .pulse-ring-1 { width: 48px; height: 48px; animation-delay: 0s; }
+    .pulse-ring-2 { width: 72px; height: 72px; animation-delay: 1s; }
+    .pulse-ring-3 { width: 96px; height: 96px; animation-delay: 2s; }
+
+    @keyframes pulseRing {
+        0% { transform: translate(-50%, -50%) scale(0.5); opacity: 0.8; }
+        100% { transform: translate(-50%, -50%) scale(1.5); opacity: 0; }
+    }
+
+    /* Heart beat */
+    .heart-beat {
+        animation: heartBeat 1.5s ease-in-out infinite;
+    }
+
+    @keyframes heartBeat {
+        0%, 100% { transform: scale(1); }
+        14% { transform: scale(1.15); }
+        28% { transform: scale(1); }
+        42% { transform: scale(1.15); }
+        56% { transform: scale(1); }
+    }
+
+    /* Icon animations */
+    .icon-spin {
+        animation: iconSpin 20s linear infinite;
+    }
+
+    @keyframes iconSpin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    .icon-pulse {
+        animation: iconPulse 3s ease-in-out infinite;
+    }
+
+    @keyframes iconPulse {
+        0%, 100% { opacity: 0.5; transform: scale(1); }
+        50% { opacity: 0.8; transform: scale(1.1); }
+    }
+
+    .icon-shimmer {
+        animation: iconShimmer 3s ease-in-out infinite;
+    }
+
+    @keyframes iconShimmer {
+        0%, 100% { filter: brightness(1); }
+        50% { filter: brightness(1.3); }
+    }
+
+    /* Icon container hover */
+    .icon-container {
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .icon-container:hover {
+        transform: scale(1.1);
+        box-shadow: 0 0 30px rgba(251, 191, 36, 0.2);
+    }
+
+    /* Success ring animation */
+    .success-ring {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+        border: 2px solid rgba(20, 184, 166, 0.3);
+        animation: successRing 1s ease-out;
+    }
+
+    @keyframes successRing {
+        0% { transform: translate(-50%, -50%) scale(0); opacity: 0; }
+        50% { opacity: 1; }
+        100% { transform: translate(-50%, -50%) scale(1.5); opacity: 0; }
+    }
+
+    /* Menu animations */
+    .animate-spin-in {
+        animation: spinIn 0.3s ease;
+    }
+
+    @keyframes spinIn {
+        from { transform: rotate(-90deg); opacity: 0; }
+        to { transform: rotate(0deg); opacity: 1; }
+    }
+
+    .animate-spin-slow {
+        animation: spinSlow 10s linear infinite;
+    }
+
+    @keyframes spinSlow {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    /* Slide in animation */
+    @keyframes slideIn {
+        from { opacity: 0; transform: translateX(-10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+
+    /* Star pop animation */
+    @keyframes starPop {
+        0% { transform: scale(0); opacity: 0; }
+        50% { transform: scale(1.2); }
+        100% { transform: scale(1); opacity: 1; }
+    }
+
     /* Smooth scroll */
     :global(html) {
         scroll-behavior: smooth;
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion: reduce) {
+        .reveal-section {
+            opacity: 1;
+            transform: none;
+            transition: none;
+        }
+
+        .animate-float-slow,
+        .animate-float-medium,
+        .animate-float-fast,
+        .animate-float-particle,
+        .heart-beat,
+        .icon-spin,
+        .icon-pulse,
+        .icon-shimmer,
+        .pulse-ring,
+        .scroll-dot {
+            animation: none;
+        }
+    }
+
+    /* Focus states for keyboard navigation */
+    :global(a:focus-visible),
+    :global(button:focus-visible),
+    :global(input:focus-visible) {
+        outline: 2px solid rgba(251, 191, 36, 0.5);
+        outline-offset: 4px;
+    }
+
+    /* Easter egg animations */
+    .easter-egg-container {
+        animation: easterFadeIn 0.5s ease, easterFadeOut 0.5s ease 4.5s forwards;
+    }
+
+    .easter-heart {
+        animation: heartFloat 3s ease-in-out infinite;
+    }
+
+    @keyframes heartFloat {
+        0% { transform: translateY(100vh) rotate(0deg); opacity: 0; }
+        10% { opacity: 1; }
+        90% { opacity: 1; }
+        100% { transform: translateY(-100px) rotate(360deg); opacity: 0; }
+    }
+
+    .easter-message {
+        animation: easterMessagePop 0.5s ease 0.3s both;
+    }
+
+    @keyframes easterMessagePop {
+        0% { transform: translate(-50%, -50%) scale(0); opacity: 0; }
+        50% { transform: translate(-50%, -50%) scale(1.1); }
+        100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+    }
+
+    @keyframes easterFadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    @keyframes easterFadeOut {
+        from { opacity: 1; }
+        to { opacity: 0; }
+    }
+
+    /* Loading skeleton */
+    .skeleton {
+        background: linear-gradient(90deg, rgba(255,255,255,0.05) 25%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.05) 75%);
+        background-size: 200% 100%;
+        animation: shimmer 1.5s infinite;
+    }
+
+    @keyframes shimmer {
+        0% { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+    }
+
+    /* Touch feedback */
+    @media (hover: none) {
+        .card-3d:active {
+            transform: scale(0.98);
+        }
+
+        .nav-link:active,
+        a:active {
+            opacity: 0.7;
+        }
     }
 </style>

--- a/frontend/src/routes/marketing2/features/+page.svelte
+++ b/frontend/src/routes/marketing2/features/+page.svelte
@@ -11,10 +11,13 @@
         FileText,
         Heart,
         Shield,
-        Briefcase
+        Briefcase,
+        Menu,
+        X
     } from "lucide-svelte";
 
     let langMenuOpen = $state(false);
+    let mobileMenuOpen = $state(false);
 
     function reveal(node: HTMLElement) {
         const observer = new IntersectionObserver(
@@ -41,6 +44,17 @@
     });
 </script>
 
+<svelte:head>
+    <title>{$m2t.metaTitleFeatures}</title>
+    <meta name="description" content={$m2t.metaDescFeatures} />
+    <meta property="og:title" content={$m2t.metaTitleFeatures} />
+    <meta property="og:description" content={$m2t.metaDescFeatures} />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={$m2t.metaTitleFeatures} />
+    <meta name="twitter:description" content={$m2t.metaDescFeatures} />
+</svelte:head>
+
 <div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
     <!-- Subtle Background -->
     <div class="fixed inset-0 z-0 pointer-events-none">
@@ -65,6 +79,19 @@
             </nav>
 
             <div class="flex items-center gap-4">
+                <!-- Mobile menu button -->
+                <button
+                    onclick={() => mobileMenuOpen = !mobileMenuOpen}
+                    class="md:hidden text-white/60 hover:text-white transition-colors p-2"
+                    aria-label="Toggle menu"
+                >
+                    {#if mobileMenuOpen}
+                        <X size={24} />
+                    {:else}
+                        <Menu size={24} />
+                    {/if}
+                </button>
+
                 <div class="relative">
                     <button
                         onclick={() => langMenuOpen = !langMenuOpen}
@@ -102,6 +129,38 @@
                 </a>
             </div>
         </div>
+
+        <!-- Mobile menu -->
+        {#if mobileMenuOpen}
+            <div
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
+                transition:fade={{ duration: 150 }}
+            >
+                <nav class="flex flex-col px-6 py-4 space-y-4">
+                    <a
+                        href="/marketing2/how"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navHow}
+                    </a>
+                    <a
+                        href="/marketing2/features"
+                        class="text-white py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navFeatures}
+                    </a>
+                    <a
+                        href="/marketing2#security"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navSecurity}
+                    </a>
+                </nav>
+            </div>
+        {/if}
     </header>
 
     <main class="relative z-10 pt-24">
@@ -272,13 +331,20 @@
 
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-white/5">
-        <div class="max-w-4xl mx-auto text-center space-y-4">
-            <p class="text-xs text-white/30">
-                {$m2t.footerDisclaimer}
-            </p>
-            <p class="text-sm text-white/20 font-serif italic">
-                {$m2t.footerTagline}
-            </p>
+        <div class="max-w-4xl mx-auto">
+            <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
+                <a href="/marketing2/how" class="hover:text-white/60 transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="text-white/60">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+            <div class="text-center space-y-4">
+                <p class="text-xs text-white/30">
+                    {$m2t.footerDisclaimer}
+                </p>
+                <p class="text-sm text-white/20 font-serif italic">
+                    {$m2t.footerTagline}
+                </p>
+            </div>
         </div>
     </footer>
 </div>

--- a/frontend/src/routes/marketing2/features/+page.svelte
+++ b/frontend/src/routes/marketing2/features/+page.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { fade } from "svelte/transition";
+    import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
+    import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
+    import {
+        ArrowRight,
+        ArrowLeft,
+        ChevronDown,
+        Globe,
+        FileText,
+        Heart,
+        Shield,
+        Briefcase
+    } from "lucide-svelte";
+
+    let langMenuOpen = $state(false);
+
+    function reveal(node: HTMLElement) {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        node.classList.add("revealed");
+                    }
+                });
+            },
+            { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
+        );
+        observer.observe(node);
+        return { destroy: () => observer.disconnect() };
+    }
+
+    function setLanguage(lang: Marketing2Language) {
+        m2Language.set(lang);
+        langMenuOpen = false;
+    }
+
+    onMount(() => {
+        window.scrollTo(0, 0);
+    });
+</script>
+
+<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Subtle Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none">
+        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+        <div
+            class="absolute inset-0 opacity-[0.03]"
+            style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\"0 0 256 256\" xmlns=\"http://www.w3.org/2000/svg\"%3E%3Cfilter id=\"noise\"%3E%3CfeTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" numOctaves=\"4\" stitchTiles=\"stitch\"/%3E%3C/filter%3E%3Crect width=\"100%25\" height=\"100%25\" filter=\"url(%23noise)\"/%3E%3C/svg%3E');"
+        ></div>
+    </div>
+
+    <!-- Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
+        <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+                Continuum
+            </a>
+
+            <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
+                <a href="/marketing2/how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="text-white">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+
+            <div class="flex items-center gap-4">
+                <div class="relative">
+                    <button
+                        onclick={() => langMenuOpen = !langMenuOpen}
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                    >
+                        <Globe size={16} />
+                        <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
+                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                    </button>
+
+                    {#if langMenuOpen}
+                        <div
+                            class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
+                            transition:fade={{ duration: 150 }}
+                        >
+                            {#each availableLanguages as lang}
+                                <button
+                                    onclick={() => setLanguage(lang.code as Marketing2Language)}
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class:text-amber-400={$m2Language === lang.code}
+                                    class:text-white/70={$m2Language !== lang.code}
+                                >
+                                    {lang.native}
+                                </button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+
+                <a
+                    href="/login"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                >
+                    {$m2t.navLogin}
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <main class="relative z-10 pt-24">
+        <!-- Hero -->
+        <section class="py-20 px-6">
+            <div class="max-w-3xl mx-auto text-center">
+                <a
+                    href="/marketing2"
+                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-colors text-sm mb-8"
+                >
+                    {#if $isRTL}
+                        <ArrowRight size={16} />
+                    {:else}
+                        <ArrowLeft size={16} />
+                    {/if}
+                    Continuum
+                </a>
+
+                <h1 class="text-4xl md:text-5xl font-serif text-white/90 mb-6">
+                    {$m2t.featuresTitle}
+                </h1>
+                <p class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto">
+                    {$m2t.featuresIntro}
+                </p>
+            </div>
+        </section>
+
+        <!-- The Four Cards -->
+        <section class="py-16 px-6">
+            <div class="max-w-5xl mx-auto">
+                <div class="grid md:grid-cols-2 gap-8">
+                    <!-- The Practical -->
+                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
+                        <div class="w-14 h-14 rounded-2xl bg-amber-500/10 flex items-center justify-center mb-6">
+                            <FileText size={28} class="text-amber-400/70" />
+                        </div>
+                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePracticalTitle}</h2>
+                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePracticalDesc}</p>
+                        <ul class="space-y-3 text-sm text-white/40">
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
+                                {$m2t.practicalItem1}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
+                                {$m2t.practicalItem2}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
+                                {$m2t.practicalItem3}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
+                                {$m2t.practicalItem4}
+                            </li>
+                        </ul>
+                    </div>
+
+                    <!-- The Personal -->
+                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
+                        <div class="w-14 h-14 rounded-2xl bg-rose-500/10 flex items-center justify-center mb-6">
+                            <Heart size={28} class="text-rose-400/70" />
+                        </div>
+                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePersonalTitle}</h2>
+                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePersonalDesc}</p>
+                        <ul class="space-y-3 text-sm text-white/40">
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
+                                {$m2t.personalItem1}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
+                                {$m2t.personalItem2}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
+                                {$m2t.personalItem3}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
+                                {$m2t.personalItem4}
+                            </li>
+                        </ul>
+                    </div>
+
+                    <!-- The Protective -->
+                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
+                        <div class="w-14 h-14 rounded-2xl bg-teal-500/10 flex items-center justify-center mb-6">
+                            <Shield size={28} class="text-teal-400/70" />
+                        </div>
+                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featureProtectiveTitle}</h2>
+                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featureProtectiveDesc}</p>
+                        <ul class="space-y-3 text-sm text-white/40">
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
+                                {$m2t.protectiveItem1}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
+                                {$m2t.protectiveItem2}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
+                                {$m2t.protectiveItem3}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
+                                {$m2t.protectiveItem4}
+                            </li>
+                        </ul>
+                    </div>
+
+                    <!-- The Prepared -->
+                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
+                        <div class="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mb-6">
+                            <Briefcase size={28} class="text-indigo-400/70" />
+                        </div>
+                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePreparedTitle}</h2>
+                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePreparedDesc}</p>
+                        <ul class="space-y-3 text-sm text-white/40">
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
+                                {$m2t.preparedItem1}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
+                                {$m2t.preparedItem2}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
+                                {$m2t.preparedItem3}
+                            </li>
+                            <li class="flex items-center gap-3">
+                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
+                                {$m2t.preparedItem4}
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- And More -->
+        <section class="py-20 px-6">
+            <div class="max-w-2xl mx-auto text-center reveal-section" use:reveal>
+                <p class="text-lg text-white/40 leading-relaxed mb-8">
+                    {$m2t.featuresMore}
+                </p>
+                <p class="text-base text-white/30 italic">
+                    {$m2t.featuresMoreSub}
+                </p>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="py-20 px-6">
+            <div class="max-w-xl mx-auto text-center reveal-section" use:reveal>
+                <a
+                    href="/marketing2"
+                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
+                >
+                    {$m2t.ctaPrimary}
+                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="py-12 px-6 border-t border-white/5">
+        <div class="max-w-4xl mx-auto text-center space-y-4">
+            <p class="text-xs text-white/30">
+                {$m2t.footerDisclaimer}
+            </p>
+            <p class="text-sm text-white/20 font-serif italic">
+                {$m2t.footerTagline}
+            </p>
+        </div>
+    </footer>
+</div>
+
+<style>
+    .reveal-section {
+        opacity: 0;
+        transform: translateY(30px);
+        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+    }
+
+    .reveal-section.revealed {
+        opacity: 1;
+        transform: translateY(0);
+    }
+</style>

--- a/frontend/src/routes/marketing2/features/+page.svelte
+++ b/frontend/src/routes/marketing2/features/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { fade } from "svelte/transition";
+    import { fade, fly, slide } from "svelte/transition";
+    import { backOut } from "svelte/easing";
+    import { spring, tweened } from "svelte/motion";
     import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
     import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
     import {
@@ -18,13 +20,33 @@
 
     let langMenuOpen = $state(false);
     let mobileMenuOpen = $state(false);
+    let scrollY = $state(0);
+    let innerHeight = $state(0);
+    let innerWidth = $state(0);
+    let prefersReducedMotion = $state(false);
 
-    function reveal(node: HTMLElement) {
+    // Spring physics for cursor glow
+    const cursorGlow = spring({ x: 0, y: 0 }, { stiffness: 0.1, damping: 0.4 });
+    const scrollProgress = tweened(0, { duration: 150 });
+
+    // Parallax offsets
+    const floatOffset1 = $derived(scrollY * 0.04);
+    const floatOffset2 = $derived(scrollY * 0.06);
+
+    function reveal(node: HTMLElement, options: { delay?: number } = {}) {
+        if (prefersReducedMotion) {
+            node.classList.add("revealed");
+            return { destroy: () => {} };
+        }
+
         const observer = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {
                     if (entry.isIntersecting) {
-                        node.classList.add("revealed");
+                        const delay = options.delay || 0;
+                        setTimeout(() => {
+                            node.classList.add("revealed");
+                        }, delay);
                     }
                 });
             },
@@ -34,6 +56,39 @@
         return { destroy: () => observer.disconnect() };
     }
 
+    // 3D card tilt effect
+    function tilt3D(node: HTMLElement) {
+        if (prefersReducedMotion) return { destroy: () => {} };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            const rect = node.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            const centerX = rect.width / 2;
+            const centerY = rect.height / 2;
+            const rotateX = (y - centerY) / 25;
+            const rotateY = (centerX - x) / 25;
+
+            node.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) translateY(-8px) scale(1.02)`;
+            node.style.boxShadow = `${rotateY * 2}px ${rotateX * 2}px 40px rgba(0,0,0,0.3)`;
+        };
+
+        const handleMouseLeave = () => {
+            node.style.transform = "perspective(1000px) rotateX(0) rotateY(0) translateY(0) scale(1)";
+            node.style.boxShadow = "0 0 0 rgba(0,0,0,0)";
+        };
+
+        node.addEventListener("mousemove", handleMouseMove);
+        node.addEventListener("mouseleave", handleMouseLeave);
+
+        return {
+            destroy() {
+                node.removeEventListener("mousemove", handleMouseMove);
+                node.removeEventListener("mouseleave", handleMouseLeave);
+            }
+        };
+    }
+
     function setLanguage(lang: Marketing2Language) {
         m2Language.set(lang);
         langMenuOpen = false;
@@ -41,7 +96,60 @@
 
     onMount(() => {
         window.scrollTo(0, 0);
+        prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+        const updateScroll = () => {
+            const docHeight = document.documentElement.scrollHeight - innerHeight;
+            scrollProgress.set(docHeight > 0 ? scrollY / docHeight : 0);
+        };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            cursorGlow.set({ x: e.clientX, y: e.clientY });
+        };
+
+        window.addEventListener("scroll", updateScroll);
+        window.addEventListener("mousemove", handleMouseMove);
+
+        return () => {
+            window.removeEventListener("scroll", updateScroll);
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
     });
+
+    const featureCards = $derived([
+        {
+            icon: FileText,
+            title: $m2t.featurePracticalTitle,
+            desc: $m2t.featurePracticalDesc,
+            items: [$m2t.practicalItem1, $m2t.practicalItem2, $m2t.practicalItem3, $m2t.practicalItem4],
+            color: "amber",
+            iconClass: "text-amber-400/70"
+        },
+        {
+            icon: Heart,
+            title: $m2t.featurePersonalTitle,
+            desc: $m2t.featurePersonalDesc,
+            items: [$m2t.personalItem1, $m2t.personalItem2, $m2t.personalItem3, $m2t.personalItem4],
+            color: "rose",
+            iconClass: "text-rose-400/70"
+        },
+        {
+            icon: Shield,
+            title: $m2t.featureProtectiveTitle,
+            desc: $m2t.featureProtectiveDesc,
+            items: [$m2t.protectiveItem1, $m2t.protectiveItem2, $m2t.protectiveItem3, $m2t.protectiveItem4],
+            color: "teal",
+            iconClass: "text-teal-400/70"
+        },
+        {
+            icon: Briefcase,
+            title: $m2t.featurePreparedTitle,
+            desc: $m2t.featurePreparedDesc,
+            items: [$m2t.preparedItem1, $m2t.preparedItem2, $m2t.preparedItem3, $m2t.preparedItem4],
+            color: "indigo",
+            iconClass: "text-indigo-400/70"
+        }
+    ]);
 </script>
 
 <svelte:head>
@@ -55,10 +163,63 @@
     <meta name="twitter:description" content={$m2t.metaDescFeatures} />
 </svelte:head>
 
-<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
-    <!-- Subtle Background -->
-    <div class="fixed inset-0 z-0 pointer-events-none">
-        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+<svelte:window bind:scrollY bind:innerHeight bind:innerWidth />
+
+<div class="min-h-screen bg-[#0a0a0b] text-white overflow-x-hidden" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Cursor Glow Effect (Desktop only) -->
+    {#if innerWidth > 768 && !prefersReducedMotion}
+        <div
+            class="pointer-events-none fixed z-50 w-96 h-96 rounded-full opacity-20 blur-3xl"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.15) 0%, transparent 70%);
+                left: {$cursorGlow.x - 192}px;
+                top: {$cursorGlow.y - 192}px;
+            "
+        ></div>
+    {/if}
+
+    <!-- Scroll Progress Indicator -->
+    <div
+        class="fixed top-0 left-0 h-[2px] bg-gradient-to-r from-amber-500 via-teal-500 to-rose-500 z-[100] origin-left"
+        style="transform: scaleX({$scrollProgress})"
+    ></div>
+
+    <!-- Animated Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none overflow-hidden">
+        <div
+            class="absolute w-[700px] h-[700px] rounded-full opacity-20 blur-[100px] animate-float-slow"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.1) 0%, transparent 70%);
+                top: -10%;
+                right: -20%;
+                transform: translateY({floatOffset1}px);
+            "
+        ></div>
+        <div
+            class="absolute w-[500px] h-[500px] rounded-full opacity-15 blur-[80px] animate-float-medium"
+            style="
+                background: radial-gradient(circle, rgba(244, 63, 94, 0.1) 0%, transparent 70%);
+                bottom: 20%;
+                left: -10%;
+                transform: translateY({-floatOffset2}px);
+            "
+        ></div>
+
+        <!-- Floating particles -->
+        {#if !prefersReducedMotion}
+            {#each Array(8) as _, i}
+                <div
+                    class="absolute w-1 h-1 rounded-full bg-white/10 animate-float-particle"
+                    style="
+                        left: {15 + (i * 10)}%;
+                        top: {25 + (i * 6) % 50}%;
+                        animation-delay: {i * 0.7}s;
+                        animation-duration: {7 + (i % 3)}s;
+                    "
+                ></div>
+            {/each}
+        {/if}
+
         <div
             class="absolute inset-0 opacity-[0.03]"
             style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\"0 0 256 256\" xmlns=\"http://www.w3.org/2000/svg\"%3E%3Cfilter id=\"noise\"%3E%3CfeTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" numOctaves=\"4\" stitchTiles=\"stitch\"/%3E%3C/filter%3E%3Crect width=\"100%25\" height=\"100%25\" filter=\"url(%23noise)\"/%3E%3C/svg%3E');"
@@ -68,51 +229,53 @@
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-all duration-300 hover:tracking-wider">
                 Continuum
             </a>
 
             <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
-                <a href="/marketing2/how" class="hover:text-white transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/how" class="nav-link">{$m2t.navHow}</a>
                 <a href="/marketing2/features" class="text-white">{$m2t.navFeatures}</a>
-                <a href="/marketing2#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2#security" class="nav-link">{$m2t.navSecurity}</a>
             </nav>
 
             <div class="flex items-center gap-4">
-                <!-- Mobile menu button -->
                 <button
                     onclick={() => mobileMenuOpen = !mobileMenuOpen}
                     class="md:hidden text-white/60 hover:text-white transition-colors p-2"
                     aria-label="Toggle menu"
                 >
-                    {#if mobileMenuOpen}
-                        <X size={24} />
-                    {:else}
-                        <Menu size={24} />
-                    {/if}
+                    <div class="relative w-6 h-6">
+                        {#if mobileMenuOpen}
+                            <X size={24} class="absolute inset-0 animate-spin-in" />
+                        {:else}
+                            <Menu size={24} class="absolute inset-0" />
+                        {/if}
+                    </div>
                 </button>
 
                 <div class="relative">
                     <button
                         onclick={() => langMenuOpen = !langMenuOpen}
-                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm group"
                     >
-                        <Globe size={16} />
+                        <Globe size={16} class="group-hover:animate-spin-slow" />
                         <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
-                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                        <ChevronDown size={14} class="transition-transform duration-300" class:rotate-180={langMenuOpen} />
                     </button>
 
                     {#if langMenuOpen}
                         <div
                             class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
-                            transition:fade={{ duration: 150 }}
+                            transition:fly={{ y: -10, duration: 200 }}
                         >
-                            {#each availableLanguages as lang}
+                            {#each availableLanguages as lang, i}
                                 <button
                                     onclick={() => setLanguage(lang.code as Marketing2Language)}
-                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-all duration-200"
                                     class:text-amber-400={$m2Language === lang.code}
                                     class:text-white/70={$m2Language !== lang.code}
+                                    style="animation: slideIn 0.2s ease {i * 0.05}s both"
                                 >
                                     {lang.native}
                                 </button>
@@ -123,41 +286,35 @@
 
                 <a
                     href="/login"
-                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all duration-300 hover:shadow-[0_0_20px_rgba(251,191,36,0.2)]"
                 >
                     {$m2t.navLogin}
                 </a>
             </div>
         </div>
 
-        <!-- Mobile menu -->
         {#if mobileMenuOpen}
             <div
-                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
-                transition:fade={{ duration: 150 }}
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md overflow-hidden"
+                transition:slide={{ duration: 300 }}
             >
-                <nav class="flex flex-col px-6 py-4 space-y-4">
-                    <a
-                        href="/marketing2/how"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navHow}
-                    </a>
-                    <a
-                        href="/marketing2/features"
-                        class="text-white py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navFeatures}
-                    </a>
-                    <a
-                        href="/marketing2#security"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navSecurity}
-                    </a>
+                <nav class="flex flex-col px-6 py-4 space-y-2">
+                    {#each [
+                        { href: "/marketing2/how", label: $m2t.navHow, active: false },
+                        { href: "/marketing2/features", label: $m2t.navFeatures, active: true },
+                        { href: "/marketing2#security", label: $m2t.navSecurity, active: false }
+                    ] as item, i}
+                        <a
+                            href={item.href}
+                            class="transition-all duration-200 py-3 border-b border-white/5 last:border-0"
+                            class:text-white={item.active}
+                            class:text-white/60={!item.active}
+                            onclick={() => mobileMenuOpen = false}
+                            style="animation: slideIn 0.3s ease {i * 0.1}s both"
+                        >
+                            {item.label}
+                        </a>
+                    {/each}
                 </nav>
             </div>
         {/if}
@@ -169,20 +326,27 @@
             <div class="max-w-3xl mx-auto text-center">
                 <a
                     href="/marketing2"
-                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-colors text-sm mb-8"
+                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-all duration-300 text-sm mb-8 group"
+                    in:fade={{ duration: 300, delay: 100 }}
                 >
                     {#if $isRTL}
-                        <ArrowRight size={16} />
+                        <ArrowRight size={16} class="group-hover:translate-x-1 transition-transform" />
                     {:else}
-                        <ArrowLeft size={16} />
+                        <ArrowLeft size={16} class="group-hover:-translate-x-1 transition-transform" />
                     {/if}
                     Continuum
                 </a>
 
-                <h1 class="text-4xl md:text-5xl font-serif text-white/90 mb-6">
+                <h1
+                    class="text-4xl md:text-5xl font-serif text-white/90 mb-6"
+                    in:fly={{ y: 30, duration: 600, delay: 200, easing: backOut }}
+                >
                     {$m2t.featuresTitle}
                 </h1>
-                <p class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto">
+                <p
+                    class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto"
+                    in:fly={{ y: 20, duration: 600, delay: 400 }}
+                >
                     {$m2t.featuresIntro}
                 </p>
             </div>
@@ -192,113 +356,30 @@
         <section class="py-16 px-6">
             <div class="max-w-5xl mx-auto">
                 <div class="grid md:grid-cols-2 gap-8">
-                    <!-- The Practical -->
-                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
-                        <div class="w-14 h-14 rounded-2xl bg-amber-500/10 flex items-center justify-center mb-6">
-                            <FileText size={28} class="text-amber-400/70" />
+                    {#each featureCards as card, i}
+                        <div
+                            class="card-3d reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-{card.color}-500/20 transition-all duration-500"
+                            use:reveal={{ delay: i * 100 }}
+                            use:tilt3D
+                        >
+                            <div class="icon-container w-14 h-14 rounded-2xl bg-{card.color}-500/10 flex items-center justify-center mb-6">
+                                <svelte:component this={card.icon} size={28} class={card.iconClass} />
+                            </div>
+                            <h2 class="text-2xl font-serif text-white/90 mb-4">{card.title}</h2>
+                            <p class="text-white/50 leading-relaxed mb-6">{card.desc}</p>
+                            <ul class="space-y-3 text-sm text-white/40">
+                                {#each card.items as item, j}
+                                    <li
+                                        class="flex items-center gap-3 list-item-reveal"
+                                        style="animation: listItemReveal 0.4s ease {(i * 0.1) + (j * 0.05)}s both"
+                                    >
+                                        <div class="w-1.5 h-1.5 rounded-full bg-{card.color}-500/50 animate-pulse-slow"></div>
+                                        {item}
+                                    </li>
+                                {/each}
+                            </ul>
                         </div>
-                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePracticalTitle}</h2>
-                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePracticalDesc}</p>
-                        <ul class="space-y-3 text-sm text-white/40">
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
-                                {$m2t.practicalItem1}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
-                                {$m2t.practicalItem2}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
-                                {$m2t.practicalItem3}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-amber-500/50"></div>
-                                {$m2t.practicalItem4}
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- The Personal -->
-                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
-                        <div class="w-14 h-14 rounded-2xl bg-rose-500/10 flex items-center justify-center mb-6">
-                            <Heart size={28} class="text-rose-400/70" />
-                        </div>
-                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePersonalTitle}</h2>
-                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePersonalDesc}</p>
-                        <ul class="space-y-3 text-sm text-white/40">
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
-                                {$m2t.personalItem1}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
-                                {$m2t.personalItem2}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
-                                {$m2t.personalItem3}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-rose-500/50"></div>
-                                {$m2t.personalItem4}
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- The Protective -->
-                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
-                        <div class="w-14 h-14 rounded-2xl bg-teal-500/10 flex items-center justify-center mb-6">
-                            <Shield size={28} class="text-teal-400/70" />
-                        </div>
-                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featureProtectiveTitle}</h2>
-                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featureProtectiveDesc}</p>
-                        <ul class="space-y-3 text-sm text-white/40">
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
-                                {$m2t.protectiveItem1}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
-                                {$m2t.protectiveItem2}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
-                                {$m2t.protectiveItem3}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-teal-500/50"></div>
-                                {$m2t.protectiveItem4}
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- The Prepared -->
-                    <div class="reveal-section p-10 rounded-3xl bg-white/[0.02] border border-white/5 hover:border-white/10 transition-colors" use:reveal>
-                        <div class="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mb-6">
-                            <Briefcase size={28} class="text-indigo-400/70" />
-                        </div>
-                        <h2 class="text-2xl font-serif text-white/90 mb-4">{$m2t.featurePreparedTitle}</h2>
-                        <p class="text-white/50 leading-relaxed mb-6">{$m2t.featurePreparedDesc}</p>
-                        <ul class="space-y-3 text-sm text-white/40">
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
-                                {$m2t.preparedItem1}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
-                                {$m2t.preparedItem2}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
-                                {$m2t.preparedItem3}
-                            </li>
-                            <li class="flex items-center gap-3">
-                                <div class="w-1.5 h-1.5 rounded-full bg-indigo-500/50"></div>
-                                {$m2t.preparedItem4}
-                            </li>
-                        </ul>
-                    </div>
+                    {/each}
                 </div>
             </div>
         </section>
@@ -320,10 +401,10 @@
             <div class="max-w-xl mx-auto text-center reveal-section" use:reveal>
                 <a
                     href="/marketing2"
-                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
+                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all duration-300 group hover:shadow-[0_0_30px_rgba(251,191,36,0.2)]"
                 >
                     {$m2t.ctaPrimary}
-                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform duration-300" />
                 </a>
             </div>
         </section>
@@ -333,9 +414,9 @@
     <footer class="py-12 px-6 border-t border-white/5">
         <div class="max-w-4xl mx-auto">
             <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
-                <a href="/marketing2/how" class="hover:text-white/60 transition-colors">{$m2t.navHow}</a>
+                <a href="/marketing2/how" class="hover:text-white/60 transition-colors duration-300">{$m2t.navHow}</a>
                 <a href="/marketing2/features" class="text-white/60">{$m2t.navFeatures}</a>
-                <a href="/marketing2#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2#security" class="hover:text-white/60 transition-colors duration-300">{$m2t.navSecurity}</a>
             </nav>
             <div class="text-center space-y-4">
                 <p class="text-xs text-white/30">
@@ -353,11 +434,132 @@
     .reveal-section {
         opacity: 0;
         transform: translateY(30px);
-        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+        transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
     }
 
     .reveal-section.revealed {
         opacity: 1;
         transform: translateY(0);
+    }
+
+    .card-3d {
+        transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+        transform-style: preserve-3d;
+    }
+
+    .nav-link {
+        position: relative;
+        padding-bottom: 4px;
+    }
+
+    .nav-link::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 0;
+        height: 1px;
+        background: linear-gradient(90deg, rgba(251, 191, 36, 0.5), rgba(20, 184, 166, 0.5));
+        transition: width 0.3s ease;
+    }
+
+    .nav-link:hover::after {
+        width: 100%;
+    }
+
+    .nav-link:hover {
+        color: white;
+    }
+
+    .icon-container {
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .icon-container:hover {
+        transform: scale(1.1) rotate(5deg);
+    }
+
+    @keyframes float-slow {
+        0%, 100% { transform: translateY(0) rotate(0deg); }
+        50% { transform: translateY(-25px) rotate(2deg); }
+    }
+
+    @keyframes float-medium {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-18px); }
+    }
+
+    @keyframes float-particle {
+        0%, 100% { transform: translateY(0) translateX(0); opacity: 0.1; }
+        25% { transform: translateY(-25px) translateX(8px); opacity: 0.25; }
+        50% { transform: translateY(-40px) translateX(-4px); opacity: 0.15; }
+        75% { transform: translateY(-25px) translateX(4px); opacity: 0.25; }
+    }
+
+    .animate-float-slow { animation: float-slow 18s ease-in-out infinite; }
+    .animate-float-medium { animation: float-medium 14s ease-in-out infinite; }
+    .animate-float-particle { animation: float-particle 8s ease-in-out infinite; }
+
+    .animate-pulse-slow {
+        animation: pulse-slow 3s ease-in-out infinite;
+    }
+
+    @keyframes pulse-slow {
+        0%, 100% { opacity: 0.5; }
+        50% { opacity: 1; }
+    }
+
+    @keyframes listItemReveal {
+        from { opacity: 0; transform: translateX(-10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+
+    .animate-spin-in {
+        animation: spinIn 0.3s ease;
+    }
+
+    @keyframes spinIn {
+        from { transform: rotate(-90deg); opacity: 0; }
+        to { transform: rotate(0deg); opacity: 1; }
+    }
+
+    .animate-spin-slow {
+        animation: spinSlow 10s linear infinite;
+    }
+
+    @keyframes spinSlow {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    @keyframes slideIn {
+        from { opacity: 0; transform: translateX(-10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .reveal-section {
+            opacity: 1;
+            transform: none;
+            transition: none;
+        }
+
+        .animate-float-slow,
+        .animate-float-medium,
+        .animate-float-particle,
+        .animate-pulse-slow {
+            animation: none;
+        }
+
+        .list-item-reveal {
+            animation: none !important;
+            opacity: 1;
+        }
+    }
+
+    :global(a:focus-visible),
+    :global(button:focus-visible) {
+        outline: 2px solid rgba(251, 191, 36, 0.5);
+        outline-offset: 4px;
     }
 </style>

--- a/frontend/src/routes/marketing2/how/+page.svelte
+++ b/frontend/src/routes/marketing2/how/+page.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { fade } from "svelte/transition";
+    import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
+    import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
+    import {
+        ArrowRight,
+        ArrowLeft,
+        ChevronDown,
+        Globe,
+        Compass,
+        Layers,
+        Bell
+    } from "lucide-svelte";
+
+    let langMenuOpen = $state(false);
+
+    function reveal(node: HTMLElement) {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        node.classList.add("revealed");
+                    }
+                });
+            },
+            { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
+        );
+        observer.observe(node);
+        return { destroy: () => observer.disconnect() };
+    }
+
+    function setLanguage(lang: Marketing2Language) {
+        m2Language.set(lang);
+        langMenuOpen = false;
+    }
+
+    onMount(() => {
+        window.scrollTo(0, 0);
+    });
+</script>
+
+<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Subtle Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none">
+        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+        <div
+            class="absolute inset-0 opacity-[0.03]"
+            style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\"0 0 256 256\" xmlns=\"http://www.w3.org/2000/svg\"%3E%3Cfilter id=\"noise\"%3E%3CfeTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" numOctaves=\"4\" stitchTiles=\"stitch\"/%3E%3C/filter%3E%3Crect width=\"100%25\" height=\"100%25\" filter=\"url(%23noise)\"/%3E%3C/svg%3E');"
+        ></div>
+    </div>
+
+    <!-- Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
+        <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+                Continuum
+            </a>
+
+            <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
+                <a href="/marketing2/how" class="text-white">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+
+            <div class="flex items-center gap-4">
+                <div class="relative">
+                    <button
+                        onclick={() => langMenuOpen = !langMenuOpen}
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                    >
+                        <Globe size={16} />
+                        <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
+                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                    </button>
+
+                    {#if langMenuOpen}
+                        <div
+                            class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
+                            transition:fade={{ duration: 150 }}
+                        >
+                            {#each availableLanguages as lang}
+                                <button
+                                    onclick={() => setLanguage(lang.code as Marketing2Language)}
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class:text-amber-400={$m2Language === lang.code}
+                                    class:text-white/70={$m2Language !== lang.code}
+                                >
+                                    {lang.native}
+                                </button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+
+                <a
+                    href="/login"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                >
+                    {$m2t.navLogin}
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <main class="relative z-10 pt-24">
+        <!-- Hero -->
+        <section class="py-20 px-6">
+            <div class="max-w-3xl mx-auto text-center">
+                <a
+                    href="/marketing2"
+                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-colors text-sm mb-8"
+                >
+                    {#if $isRTL}
+                        <ArrowRight size={16} />
+                    {:else}
+                        <ArrowLeft size={16} />
+                    {/if}
+                    Continuum
+                </a>
+
+                <h1 class="text-4xl md:text-5xl font-serif text-white/90 mb-6">
+                    {$m2t.howTitle}
+                </h1>
+                <p class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto">
+                    {$m2t.howIntro}
+                </p>
+            </div>
+        </section>
+
+        <!-- Beat 1: You Start -->
+        <section class="py-24 px-6">
+            <div class="max-w-4xl mx-auto">
+                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
+                    <div class="order-2 md:order-1">
+                        <div class="text-6xl font-serif text-white/10 mb-4">01</div>
+                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat1Title}</h2>
+                        <p class="text-lg text-white/50 leading-relaxed">
+                            {$m2t.howBeat1Desc}
+                        </p>
+                    </div>
+                    <div class="order-1 md:order-2 flex justify-center">
+                        <div class="w-32 h-32 rounded-full bg-amber-500/10 flex items-center justify-center">
+                            <Compass size={48} class="text-amber-400/60" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Connector -->
+        <div class="flex justify-center py-8">
+            <div class="w-px h-24 bg-gradient-to-b from-white/10 to-transparent"></div>
+        </div>
+
+        <!-- Beat 2: You Build -->
+        <section class="py-24 px-6">
+            <div class="max-w-4xl mx-auto">
+                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
+                    <div class="flex justify-center">
+                        <div class="w-32 h-32 rounded-full bg-teal-500/10 flex items-center justify-center">
+                            <Layers size={48} class="text-teal-400/60" />
+                        </div>
+                    </div>
+                    <div>
+                        <div class="text-6xl font-serif text-white/10 mb-4">02</div>
+                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat2Title}</h2>
+                        <p class="text-lg text-white/50 leading-relaxed">
+                            {$m2t.howBeat2Desc}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Connector -->
+        <div class="flex justify-center py-8">
+            <div class="w-px h-24 bg-gradient-to-b from-white/10 to-transparent"></div>
+        </div>
+
+        <!-- Beat 3: It Opens -->
+        <section class="py-24 px-6">
+            <div class="max-w-4xl mx-auto">
+                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
+                    <div class="order-2 md:order-1">
+                        <div class="text-6xl font-serif text-white/10 mb-4">03</div>
+                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat3Title}</h2>
+                        <p class="text-lg text-white/50 leading-relaxed">
+                            {$m2t.howBeat3Desc}
+                        </p>
+                    </div>
+                    <div class="order-1 md:order-2 flex justify-center">
+                        <div class="w-32 h-32 rounded-full bg-rose-500/10 flex items-center justify-center">
+                            <Bell size={48} class="text-rose-400/60" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- The Gift -->
+        <section class="py-24 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent">
+            <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
+                <p class="text-2xl font-serif text-white/70 leading-relaxed mb-8">
+                    "{$m2t.pulseGift}"
+                </p>
+                <div class="w-16 h-px bg-amber-500/30 mx-auto"></div>
+            </div>
+        </section>
+
+        <!-- CTA -->
+        <section class="py-20 px-6">
+            <div class="max-w-xl mx-auto text-center reveal-section" use:reveal>
+                <p class="text-lg text-white/40 mb-8">
+                    {$m2t.invitationDesc}
+                </p>
+                <a
+                    href="/marketing2"
+                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
+                >
+                    {$m2t.ctaPrimary}
+                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="py-12 px-6 border-t border-white/5">
+        <div class="max-w-4xl mx-auto text-center space-y-4">
+            <p class="text-xs text-white/30">
+                {$m2t.footerDisclaimer}
+            </p>
+            <p class="text-sm text-white/20 font-serif italic">
+                {$m2t.footerTagline}
+            </p>
+        </div>
+    </footer>
+</div>
+
+<style>
+    .reveal-section {
+        opacity: 0;
+        transform: translateY(30px);
+        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+    }
+
+    .reveal-section.revealed {
+        opacity: 1;
+        transform: translateY(0);
+    }
+</style>

--- a/frontend/src/routes/marketing2/how/+page.svelte
+++ b/frontend/src/routes/marketing2/how/+page.svelte
@@ -10,10 +10,13 @@
         Globe,
         Compass,
         Layers,
-        Bell
+        Bell,
+        Menu,
+        X
     } from "lucide-svelte";
 
     let langMenuOpen = $state(false);
+    let mobileMenuOpen = $state(false);
 
     function reveal(node: HTMLElement) {
         const observer = new IntersectionObserver(
@@ -40,6 +43,17 @@
     });
 </script>
 
+<svelte:head>
+    <title>{$m2t.metaTitleHow}</title>
+    <meta name="description" content={$m2t.metaDescHow} />
+    <meta property="og:title" content={$m2t.metaTitleHow} />
+    <meta property="og:description" content={$m2t.metaDescHow} />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={$m2t.metaTitleHow} />
+    <meta name="twitter:description" content={$m2t.metaDescHow} />
+</svelte:head>
+
 <div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
     <!-- Subtle Background -->
     <div class="fixed inset-0 z-0 pointer-events-none">
@@ -64,6 +78,19 @@
             </nav>
 
             <div class="flex items-center gap-4">
+                <!-- Mobile menu button -->
+                <button
+                    onclick={() => mobileMenuOpen = !mobileMenuOpen}
+                    class="md:hidden text-white/60 hover:text-white transition-colors p-2"
+                    aria-label="Toggle menu"
+                >
+                    {#if mobileMenuOpen}
+                        <X size={24} />
+                    {:else}
+                        <Menu size={24} />
+                    {/if}
+                </button>
+
                 <div class="relative">
                     <button
                         onclick={() => langMenuOpen = !langMenuOpen}
@@ -101,6 +128,38 @@
                 </a>
             </div>
         </div>
+
+        <!-- Mobile menu -->
+        {#if mobileMenuOpen}
+            <div
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
+                transition:fade={{ duration: 150 }}
+            >
+                <nav class="flex flex-col px-6 py-4 space-y-4">
+                    <a
+                        href="/marketing2/how"
+                        class="text-white py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navHow}
+                    </a>
+                    <a
+                        href="/marketing2/features"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navFeatures}
+                    </a>
+                    <a
+                        href="/marketing2#security"
+                        class="text-white/60 hover:text-white transition-colors py-2"
+                        onclick={() => mobileMenuOpen = false}
+                    >
+                        {$m2t.navSecurity}
+                    </a>
+                </nav>
+            </div>
+        {/if}
     </header>
 
     <main class="relative z-10 pt-24">
@@ -227,13 +286,20 @@
 
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-white/5">
-        <div class="max-w-4xl mx-auto text-center space-y-4">
-            <p class="text-xs text-white/30">
-                {$m2t.footerDisclaimer}
-            </p>
-            <p class="text-sm text-white/20 font-serif italic">
-                {$m2t.footerTagline}
-            </p>
+        <div class="max-w-4xl mx-auto">
+            <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
+                <a href="/marketing2/how" class="text-white/60">{$m2t.navHow}</a>
+                <a href="/marketing2/features" class="hover:text-white/60 transition-colors">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+            </nav>
+            <div class="text-center space-y-4">
+                <p class="text-xs text-white/30">
+                    {$m2t.footerDisclaimer}
+                </p>
+                <p class="text-sm text-white/20 font-serif italic">
+                    {$m2t.footerTagline}
+                </p>
+            </div>
         </div>
     </footer>
 </div>

--- a/frontend/src/routes/marketing2/how/+page.svelte
+++ b/frontend/src/routes/marketing2/how/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { fade } from "svelte/transition";
+    import { fade, fly, slide } from "svelte/transition";
+    import { backOut, elasticOut } from "svelte/easing";
+    import { spring, tweened } from "svelte/motion";
     import { m2Language, m2t, availableLanguages, isRTL } from "$lib/stores/marketing2";
     import type { Marketing2Language } from "$lib/stores/marketing2Dictionary";
     import {
@@ -17,13 +19,36 @@
 
     let langMenuOpen = $state(false);
     let mobileMenuOpen = $state(false);
+    let scrollY = $state(0);
+    let innerHeight = $state(0);
+    let innerWidth = $state(0);
+    let prefersReducedMotion = $state(false);
 
-    function reveal(node: HTMLElement) {
+    // Spring physics for cursor glow
+    const cursorGlow = spring({ x: 0, y: 0 }, { stiffness: 0.1, damping: 0.4 });
+    const scrollProgress = tweened(0, { duration: 150 });
+
+    // Parallax offsets
+    const floatOffset1 = $derived(scrollY * 0.05);
+    const floatOffset2 = $derived(scrollY * 0.07);
+
+    // Connector line animation based on scroll
+    const connectorProgress = $derived(Math.min(1, scrollY / (innerHeight * 2)));
+
+    function reveal(node: HTMLElement, options: { delay?: number } = {}) {
+        if (prefersReducedMotion) {
+            node.classList.add("revealed");
+            return { destroy: () => {} };
+        }
+
         const observer = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {
                     if (entry.isIntersecting) {
-                        node.classList.add("revealed");
+                        const delay = options.delay || 0;
+                        setTimeout(() => {
+                            node.classList.add("revealed");
+                        }, delay);
                     }
                 });
             },
@@ -33,6 +58,29 @@
         return { destroy: () => observer.disconnect() };
     }
 
+    // Icon animation on hover
+    function iconAnimate(node: HTMLElement) {
+        if (prefersReducedMotion) return { destroy: () => {} };
+
+        const handleMouseEnter = () => {
+            node.style.transform = "scale(1.15) rotate(10deg)";
+        };
+
+        const handleMouseLeave = () => {
+            node.style.transform = "scale(1) rotate(0deg)";
+        };
+
+        node.addEventListener("mouseenter", handleMouseEnter);
+        node.addEventListener("mouseleave", handleMouseLeave);
+
+        return {
+            destroy() {
+                node.removeEventListener("mouseenter", handleMouseEnter);
+                node.removeEventListener("mouseleave", handleMouseLeave);
+            }
+        };
+    }
+
     function setLanguage(lang: Marketing2Language) {
         m2Language.set(lang);
         langMenuOpen = false;
@@ -40,7 +88,52 @@
 
     onMount(() => {
         window.scrollTo(0, 0);
+        prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+        const updateScroll = () => {
+            const docHeight = document.documentElement.scrollHeight - innerHeight;
+            scrollProgress.set(docHeight > 0 ? scrollY / docHeight : 0);
+        };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            cursorGlow.set({ x: e.clientX, y: e.clientY });
+        };
+
+        window.addEventListener("scroll", updateScroll);
+        window.addEventListener("mousemove", handleMouseMove);
+
+        return () => {
+            window.removeEventListener("scroll", updateScroll);
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
     });
+
+    const beats = $derived([
+        {
+            num: "01",
+            title: $m2t.howBeat1Title,
+            desc: $m2t.howBeat1Desc,
+            icon: Compass,
+            color: "amber",
+            iconClass: "text-amber-400/60"
+        },
+        {
+            num: "02",
+            title: $m2t.howBeat2Title,
+            desc: $m2t.howBeat2Desc,
+            icon: Layers,
+            color: "teal",
+            iconClass: "text-teal-400/60"
+        },
+        {
+            num: "03",
+            title: $m2t.howBeat3Title,
+            desc: $m2t.howBeat3Desc,
+            icon: Bell,
+            color: "rose",
+            iconClass: "text-rose-400/60"
+        }
+    ]);
 </script>
 
 <svelte:head>
@@ -54,10 +147,63 @@
     <meta name="twitter:description" content={$m2t.metaDescHow} />
 </svelte:head>
 
-<div class="min-h-screen bg-[#0a0a0b] text-white" dir={$isRTL ? "rtl" : "ltr"}>
-    <!-- Subtle Background -->
-    <div class="fixed inset-0 z-0 pointer-events-none">
-        <div class="absolute inset-0 bg-gradient-to-b from-amber-950/10 via-transparent to-transparent"></div>
+<svelte:window bind:scrollY bind:innerHeight bind:innerWidth />
+
+<div class="min-h-screen bg-[#0a0a0b] text-white overflow-x-hidden" dir={$isRTL ? "rtl" : "ltr"}>
+    <!-- Cursor Glow Effect (Desktop only) -->
+    {#if innerWidth > 768 && !prefersReducedMotion}
+        <div
+            class="pointer-events-none fixed z-50 w-96 h-96 rounded-full opacity-20 blur-3xl"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.15) 0%, transparent 70%);
+                left: {$cursorGlow.x - 192}px;
+                top: {$cursorGlow.y - 192}px;
+            "
+        ></div>
+    {/if}
+
+    <!-- Scroll Progress Indicator -->
+    <div
+        class="fixed top-0 left-0 h-[2px] bg-gradient-to-r from-amber-500 via-teal-500 to-rose-500 z-[100] origin-left"
+        style="transform: scaleX({$scrollProgress})"
+    ></div>
+
+    <!-- Animated Background -->
+    <div class="fixed inset-0 z-0 pointer-events-none overflow-hidden">
+        <div
+            class="absolute w-[600px] h-[600px] rounded-full opacity-20 blur-[100px] animate-float-slow"
+            style="
+                background: radial-gradient(circle, rgba(251, 191, 36, 0.1) 0%, transparent 70%);
+                top: 10%;
+                left: -15%;
+                transform: translateY({floatOffset1}px);
+            "
+        ></div>
+        <div
+            class="absolute w-[500px] h-[500px] rounded-full opacity-15 blur-[80px] animate-float-medium"
+            style="
+                background: radial-gradient(circle, rgba(20, 184, 166, 0.1) 0%, transparent 70%);
+                bottom: 10%;
+                right: -10%;
+                transform: translateY({-floatOffset2}px);
+            "
+        ></div>
+
+        <!-- Floating particles -->
+        {#if !prefersReducedMotion}
+            {#each Array(10) as _, i}
+                <div
+                    class="absolute w-1 h-1 rounded-full bg-white/10 animate-float-particle"
+                    style="
+                        left: {12 + (i * 8)}%;
+                        top: {15 + (i * 7) % 60}%;
+                        animation-delay: {i * 0.6}s;
+                        animation-duration: {6 + (i % 4)}s;
+                    "
+                ></div>
+            {/each}
+        {/if}
+
         <div
             class="absolute inset-0 opacity-[0.03]"
             style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\"0 0 256 256\" xmlns=\"http://www.w3.org/2000/svg\"%3E%3Cfilter id=\"noise\"%3E%3CfeTurbulence type=\"fractalNoise\" baseFrequency=\"0.9\" numOctaves=\"4\" stitchTiles=\"stitch\"/%3E%3C/filter%3E%3Crect width=\"100%25\" height=\"100%25\" filter=\"url(%23noise)\"/%3E%3C/svg%3E');"
@@ -67,51 +213,53 @@
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-colors">
+            <a href="/marketing2" class="text-xl font-serif tracking-wide text-white/90 hover:text-white transition-all duration-300 hover:tracking-wider">
                 Continuum
             </a>
 
             <nav class="hidden md:flex items-center gap-8 text-sm text-white/60">
                 <a href="/marketing2/how" class="text-white">{$m2t.navHow}</a>
-                <a href="/marketing2/features" class="hover:text-white transition-colors">{$m2t.navFeatures}</a>
-                <a href="/marketing2#security" class="hover:text-white transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2/features" class="nav-link">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="nav-link">{$m2t.navSecurity}</a>
             </nav>
 
             <div class="flex items-center gap-4">
-                <!-- Mobile menu button -->
                 <button
                     onclick={() => mobileMenuOpen = !mobileMenuOpen}
                     class="md:hidden text-white/60 hover:text-white transition-colors p-2"
                     aria-label="Toggle menu"
                 >
-                    {#if mobileMenuOpen}
-                        <X size={24} />
-                    {:else}
-                        <Menu size={24} />
-                    {/if}
+                    <div class="relative w-6 h-6">
+                        {#if mobileMenuOpen}
+                            <X size={24} class="absolute inset-0 animate-spin-in" />
+                        {:else}
+                            <Menu size={24} class="absolute inset-0" />
+                        {/if}
+                    </div>
                 </button>
 
                 <div class="relative">
                     <button
                         onclick={() => langMenuOpen = !langMenuOpen}
-                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm"
+                        class="flex items-center gap-2 text-white/60 hover:text-white transition-colors text-sm group"
                     >
-                        <Globe size={16} />
+                        <Globe size={16} class="group-hover:animate-spin-slow" />
                         <span class="hidden sm:inline">{availableLanguages.find(l => l.code === $m2Language)?.native}</span>
-                        <ChevronDown size={14} class="transition-transform" class:rotate-180={langMenuOpen} />
+                        <ChevronDown size={14} class="transition-transform duration-300" class:rotate-180={langMenuOpen} />
                     </button>
 
                     {#if langMenuOpen}
                         <div
                             class="absolute top-full right-0 mt-2 bg-black/95 backdrop-blur-md border border-white/10 rounded-lg py-2 min-w-[140px] shadow-xl"
-                            transition:fade={{ duration: 150 }}
+                            transition:fly={{ y: -10, duration: 200 }}
                         >
-                            {#each availableLanguages as lang}
+                            {#each availableLanguages as lang, i}
                                 <button
                                     onclick={() => setLanguage(lang.code as Marketing2Language)}
-                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-colors"
+                                    class="w-full px-4 py-2 text-left text-sm hover:bg-white/5 transition-all duration-200"
                                     class:text-amber-400={$m2Language === lang.code}
                                     class:text-white/70={$m2Language !== lang.code}
+                                    style="animation: slideIn 0.2s ease {i * 0.05}s both"
                                 >
                                     {lang.native}
                                 </button>
@@ -122,41 +270,35 @@
 
                 <a
                     href="/login"
-                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all"
+                    class="text-sm px-4 py-2 rounded-full border border-white/20 text-white/80 hover:text-white hover:border-white/40 transition-all duration-300 hover:shadow-[0_0_20px_rgba(251,191,36,0.2)]"
                 >
                     {$m2t.navLogin}
                 </a>
             </div>
         </div>
 
-        <!-- Mobile menu -->
         {#if mobileMenuOpen}
             <div
-                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md"
-                transition:fade={{ duration: 150 }}
+                class="md:hidden border-t border-white/5 bg-black/95 backdrop-blur-md overflow-hidden"
+                transition:slide={{ duration: 300 }}
             >
-                <nav class="flex flex-col px-6 py-4 space-y-4">
-                    <a
-                        href="/marketing2/how"
-                        class="text-white py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navHow}
-                    </a>
-                    <a
-                        href="/marketing2/features"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navFeatures}
-                    </a>
-                    <a
-                        href="/marketing2#security"
-                        class="text-white/60 hover:text-white transition-colors py-2"
-                        onclick={() => mobileMenuOpen = false}
-                    >
-                        {$m2t.navSecurity}
-                    </a>
+                <nav class="flex flex-col px-6 py-4 space-y-2">
+                    {#each [
+                        { href: "/marketing2/how", label: $m2t.navHow, active: true },
+                        { href: "/marketing2/features", label: $m2t.navFeatures, active: false },
+                        { href: "/marketing2#security", label: $m2t.navSecurity, active: false }
+                    ] as item, i}
+                        <a
+                            href={item.href}
+                            class="transition-all duration-200 py-3 border-b border-white/5 last:border-0"
+                            class:text-white={item.active}
+                            class:text-white/60={!item.active}
+                            onclick={() => mobileMenuOpen = false}
+                            style="animation: slideIn 0.3s ease {i * 0.1}s both"
+                        >
+                            {item.label}
+                        </a>
+                    {/each}
                 </nav>
             </div>
         {/if}
@@ -168,102 +310,97 @@
             <div class="max-w-3xl mx-auto text-center">
                 <a
                     href="/marketing2"
-                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-colors text-sm mb-8"
+                    class="inline-flex items-center gap-2 text-white/40 hover:text-white/60 transition-all duration-300 text-sm mb-8 group"
+                    in:fade={{ duration: 300, delay: 100 }}
                 >
                     {#if $isRTL}
-                        <ArrowRight size={16} />
+                        <ArrowRight size={16} class="group-hover:translate-x-1 transition-transform" />
                     {:else}
-                        <ArrowLeft size={16} />
+                        <ArrowLeft size={16} class="group-hover:-translate-x-1 transition-transform" />
                     {/if}
                     Continuum
                 </a>
 
-                <h1 class="text-4xl md:text-5xl font-serif text-white/90 mb-6">
+                <h1
+                    class="text-4xl md:text-5xl font-serif text-white/90 mb-6"
+                    in:fly={{ y: 30, duration: 600, delay: 200, easing: backOut }}
+                >
                     {$m2t.howTitle}
                 </h1>
-                <p class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto">
+                <p
+                    class="text-lg text-white/50 leading-relaxed max-w-2xl mx-auto"
+                    in:fly={{ y: 20, duration: 600, delay: 400 }}
+                >
                     {$m2t.howIntro}
                 </p>
             </div>
         </section>
 
-        <!-- Beat 1: You Start -->
-        <section class="py-24 px-6">
-            <div class="max-w-4xl mx-auto">
-                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
-                    <div class="order-2 md:order-1">
-                        <div class="text-6xl font-serif text-white/10 mb-4">01</div>
-                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat1Title}</h2>
-                        <p class="text-lg text-white/50 leading-relaxed">
-                            {$m2t.howBeat1Desc}
-                        </p>
-                    </div>
-                    <div class="order-1 md:order-2 flex justify-center">
-                        <div class="w-32 h-32 rounded-full bg-amber-500/10 flex items-center justify-center">
-                            <Compass size={48} class="text-amber-400/60" />
+        <!-- Timeline with beats -->
+        <div class="relative">
+            <!-- Animated vertical line connecting beats -->
+            <div class="absolute left-1/2 top-0 bottom-0 w-px hidden md:block">
+                <div
+                    class="w-full bg-gradient-to-b from-amber-500/30 via-teal-500/30 to-rose-500/30 origin-top"
+                    style="height: 100%; transform: scaleY({connectorProgress})"
+                ></div>
+            </div>
+
+            {#each beats as beat, i}
+                <!-- Beat Section -->
+                <section class="py-24 px-6 relative">
+                    <div class="max-w-4xl mx-auto">
+                        <div
+                            class="grid md:grid-cols-2 gap-12 items-center reveal-section"
+                            use:reveal={{ delay: i * 100 }}
+                        >
+                            <!-- Text content -->
+                            <div class={i % 2 === 0 ? "order-2 md:order-1" : ""}>
+                                <div
+                                    class="text-6xl font-serif text-white/10 mb-4 number-reveal"
+                                    style="animation: numberPop 0.6s ease {i * 0.2}s both"
+                                >
+                                    {beat.num}
+                                </div>
+                                <h2 class="text-3xl font-serif text-white/90 mb-6">{beat.title}</h2>
+                                <p class="text-lg text-white/50 leading-relaxed">
+                                    {beat.desc}
+                                </p>
+                            </div>
+
+                            <!-- Icon -->
+                            <div class={i % 2 === 0 ? "order-1 md:order-2 flex justify-center" : "flex justify-center"}>
+                                <div
+                                    class="icon-orb w-32 h-32 rounded-full bg-{beat.color}-500/10 flex items-center justify-center relative"
+                                    use:iconAnimate
+                                >
+                                    <!-- Animated rings -->
+                                    <div class="icon-ring icon-ring-1 bg-{beat.color}-500/10"></div>
+                                    <div class="icon-ring icon-ring-2 bg-{beat.color}-500/5"></div>
+                                    <svelte:component this={beat.icon} size={48} class={beat.iconClass} />
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
+                </section>
 
-        <!-- Connector -->
-        <div class="flex justify-center py-8">
-            <div class="w-px h-24 bg-gradient-to-b from-white/10 to-transparent"></div>
+                <!-- Connector dot (visible on mobile) -->
+                {#if i < beats.length - 1}
+                    <div class="flex justify-center py-4 md:hidden">
+                        <div class="w-2 h-2 rounded-full bg-white/20"></div>
+                    </div>
+                {/if}
+            {/each}
         </div>
 
-        <!-- Beat 2: You Build -->
-        <section class="py-24 px-6">
-            <div class="max-w-4xl mx-auto">
-                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
-                    <div class="flex justify-center">
-                        <div class="w-32 h-32 rounded-full bg-teal-500/10 flex items-center justify-center">
-                            <Layers size={48} class="text-teal-400/60" />
-                        </div>
-                    </div>
-                    <div>
-                        <div class="text-6xl font-serif text-white/10 mb-4">02</div>
-                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat2Title}</h2>
-                        <p class="text-lg text-white/50 leading-relaxed">
-                            {$m2t.howBeat2Desc}
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Connector -->
-        <div class="flex justify-center py-8">
-            <div class="w-px h-24 bg-gradient-to-b from-white/10 to-transparent"></div>
-        </div>
-
-        <!-- Beat 3: It Opens -->
-        <section class="py-24 px-6">
-            <div class="max-w-4xl mx-auto">
-                <div class="grid md:grid-cols-2 gap-12 items-center reveal-section" use:reveal>
-                    <div class="order-2 md:order-1">
-                        <div class="text-6xl font-serif text-white/10 mb-4">03</div>
-                        <h2 class="text-3xl font-serif text-white/90 mb-6">{$m2t.howBeat3Title}</h2>
-                        <p class="text-lg text-white/50 leading-relaxed">
-                            {$m2t.howBeat3Desc}
-                        </p>
-                    </div>
-                    <div class="order-1 md:order-2 flex justify-center">
-                        <div class="w-32 h-32 rounded-full bg-rose-500/10 flex items-center justify-center">
-                            <Bell size={48} class="text-rose-400/60" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- The Gift -->
+        <!-- The Gift Quote -->
         <section class="py-24 px-6 bg-gradient-to-b from-transparent via-white/[0.02] to-transparent">
             <div class="max-w-3xl mx-auto text-center reveal-section" use:reveal>
-                <p class="text-2xl font-serif text-white/70 leading-relaxed mb-8">
-                    "{$m2t.pulseGift}"
+                <div class="quote-marks text-6xl text-white/5 font-serif mb-4">"</div>
+                <p class="text-2xl font-serif text-white/70 leading-relaxed mb-8 italic">
+                    {$m2t.pulseGift}
                 </p>
-                <div class="w-16 h-px bg-amber-500/30 mx-auto"></div>
+                <div class="w-16 h-px bg-gradient-to-r from-transparent via-amber-500/30 to-transparent mx-auto animate-pulse-glow"></div>
             </div>
         </section>
 
@@ -275,10 +412,10 @@
                 </p>
                 <a
                     href="/marketing2"
-                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all group"
+                    class="inline-flex items-center gap-3 px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 rounded-full text-white/80 transition-all duration-300 group hover:shadow-[0_0_30px_rgba(251,191,36,0.2)]"
                 >
                     {$m2t.ctaPrimary}
-                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform" />
+                    <ArrowRight size={18} class="group-hover:translate-x-1 transition-transform duration-300" />
                 </a>
             </div>
         </section>
@@ -289,8 +426,8 @@
         <div class="max-w-4xl mx-auto">
             <nav class="flex justify-center gap-8 mb-8 text-sm text-white/40">
                 <a href="/marketing2/how" class="text-white/60">{$m2t.navHow}</a>
-                <a href="/marketing2/features" class="hover:text-white/60 transition-colors">{$m2t.navFeatures}</a>
-                <a href="/marketing2#security" class="hover:text-white/60 transition-colors">{$m2t.navSecurity}</a>
+                <a href="/marketing2/features" class="hover:text-white/60 transition-colors duration-300">{$m2t.navFeatures}</a>
+                <a href="/marketing2#security" class="hover:text-white/60 transition-colors duration-300">{$m2t.navSecurity}</a>
             </nav>
             <div class="text-center space-y-4">
                 <p class="text-xs text-white/30">
@@ -308,11 +445,157 @@
     .reveal-section {
         opacity: 0;
         transform: translateY(30px);
-        transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+        transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
     }
 
     .reveal-section.revealed {
         opacity: 1;
         transform: translateY(0);
+    }
+
+    .nav-link {
+        position: relative;
+        padding-bottom: 4px;
+    }
+
+    .nav-link::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 0;
+        height: 1px;
+        background: linear-gradient(90deg, rgba(251, 191, 36, 0.5), rgba(20, 184, 166, 0.5));
+        transition: width 0.3s ease;
+    }
+
+    .nav-link:hover::after {
+        width: 100%;
+    }
+
+    .nav-link:hover {
+        color: white;
+    }
+
+    /* Icon orb with rings */
+    .icon-orb {
+        transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    .icon-ring {
+        position: absolute;
+        border-radius: 50%;
+        animation: iconRingPulse 4s ease-in-out infinite;
+    }
+
+    .icon-ring-1 {
+        width: 150%;
+        height: 150%;
+        animation-delay: 0s;
+    }
+
+    .icon-ring-2 {
+        width: 200%;
+        height: 200%;
+        animation-delay: 2s;
+    }
+
+    @keyframes iconRingPulse {
+        0%, 100% { transform: scale(1); opacity: 0.3; }
+        50% { transform: scale(1.1); opacity: 0.1; }
+    }
+
+    /* Number pop animation */
+    @keyframes numberPop {
+        0% { transform: scale(0.5); opacity: 0; }
+        50% { transform: scale(1.1); }
+        100% { transform: scale(1); opacity: 1; }
+    }
+
+    /* Quote styling */
+    .quote-marks {
+        line-height: 1;
+    }
+
+    /* Pulse glow on divider */
+    .animate-pulse-glow {
+        animation: pulseGlow 3s ease-in-out infinite;
+    }
+
+    @keyframes pulseGlow {
+        0%, 100% { opacity: 0.3; box-shadow: 0 0 10px rgba(251, 191, 36, 0.1); }
+        50% { opacity: 0.6; box-shadow: 0 0 20px rgba(251, 191, 36, 0.3); }
+    }
+
+    /* Floating animations */
+    @keyframes float-slow {
+        0%, 100% { transform: translateY(0) rotate(0deg); }
+        50% { transform: translateY(-25px) rotate(2deg); }
+    }
+
+    @keyframes float-medium {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-20px); }
+    }
+
+    @keyframes float-particle {
+        0%, 100% { transform: translateY(0) translateX(0); opacity: 0.1; }
+        25% { transform: translateY(-30px) translateX(10px); opacity: 0.25; }
+        50% { transform: translateY(-45px) translateX(-5px); opacity: 0.15; }
+        75% { transform: translateY(-30px) translateX(5px); opacity: 0.25; }
+    }
+
+    .animate-float-slow { animation: float-slow 18s ease-in-out infinite; }
+    .animate-float-medium { animation: float-medium 14s ease-in-out infinite; }
+    .animate-float-particle { animation: float-particle 8s ease-in-out infinite; }
+
+    .animate-spin-in {
+        animation: spinIn 0.3s ease;
+    }
+
+    @keyframes spinIn {
+        from { transform: rotate(-90deg); opacity: 0; }
+        to { transform: rotate(0deg); opacity: 1; }
+    }
+
+    .animate-spin-slow {
+        animation: spinSlow 10s linear infinite;
+    }
+
+    @keyframes spinSlow {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    @keyframes slideIn {
+        from { opacity: 0; transform: translateX(-10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .reveal-section {
+            opacity: 1;
+            transform: none;
+            transition: none;
+        }
+
+        .animate-float-slow,
+        .animate-float-medium,
+        .animate-float-particle,
+        .icon-ring,
+        .animate-pulse-glow {
+            animation: none;
+        }
+
+        .number-reveal {
+            animation: none !important;
+            opacity: 1;
+        }
+    }
+
+    :global(a:focus-visible),
+    :global(button:focus-visible) {
+        outline: 2px solid rgba(251, 191, 36, 0.5);
+        outline-offset: 4px;
     }
 </style>


### PR DESCRIPTION
Implements the revised marketing website plan with:
- 7 emotional sections (Shoebox, Weight, Guide, Pulse, Distinction, Gift, Invitation)
- Full translations for EN, ES, FR, DE, RU, HE (including RTL support)
- Tone-compliant copy (invitation over instruction, acknowledgment over efficiency)
- No feature grids or overwhelming module lists
- Progressive disclosure philosophy
- Clear distinction from legal/financial advice
- Owner-focused messaging (executors come via product, not marketing)

New files:
- marketing2Dictionary.ts: All translations with tone-compliant copy
- marketing2.ts: Language store with RTL support
- /marketing2/+page.svelte: Calm, whitespace-focused design